### PR TITLE
FIX: typo for insertId.

### DIFF
--- a/src/React/MySQL/Protocal/Parser.php
+++ b/src/React/MySQL/Protocal/Parser.php
@@ -305,7 +305,7 @@ field:
 		$command = $this->queue->dequeue();
 		if ($command->equals(Command::QUERY)) {
 			$command->affectedRows = $this->affectedRows;
-			$command->indertId     = $this->insertId;
+			$command->insertId     = $this->insertId;
 			$command->warnCount    = $this->warnCount;
 			$command->message      = $this->message;
 		}


### PR DESCRIPTION
Fixed typo in the Protocol Parser when retrieving the insertId.
