### PR TITLE
Consistent connect() behavior for all connection states

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,31 @@ $connector = new \React\Socket\Connector($loop, array(
 $connection = new Connection($loop, $options, $connector);
 ```
 
+#### connect()
+
+The `connect(callable $callback): void` method can be used to
+connect to the MySQL server.
+
+It accepts a `callable $callback` parameter which is the handler that will
+be called when the connection succeeds or fails.
+
+```php
+$connection->connect(function (?Exception $error, $connection) {
+    if ($error) {
+        echo 'Connection failed: ' . $error->getMessage();
+    } else {
+        echo 'Successfully connected';
+    }
+});
+```
+
+This method should be invoked once after the `Connection` is initialized.
+You can queue additional `query()`, `ping()` and `close()` calls after
+invoking this method without having to await its resolution first.
+
+This method throws an `Exception` if the connection is already initialized,
+i.e. it MUST NOT be called more than once.
+
 ## Install
 
 The recommended way to install this library is [through Composer](https://getcomposer.org).

--- a/examples/init.php
+++ b/examples/init.php
@@ -1,9 +1,0 @@
-<?php
-
-$loader = @include __DIR__ . '/../vendor/autoload.php';
-if (!$loader) {
-    $loader = require __DIR__ . '/../../../../vendor/autoload.php';
-}
-$loader->add('React\MySQL', __DIR__ . '/../src/');
-
-return $loader;

--- a/examples/query-with-callback.php
+++ b/examples/query-with-callback.php
@@ -1,5 +1,6 @@
 <?php
-require __DIR__ . '/init.php';
+
+require __DIR__ . '/../vendor/autoload.php';
 
 //create the main loop
 $loop = React\EventLoop\Factory::create();
@@ -10,8 +11,6 @@ $connection = new React\MySQL\Connection($loop, array(
     'user'   => 'test',
     'passwd' => 'test',
 ));
-
-//connecting to mysql server, not required.
 
 $connection->connect(function () {});
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -204,6 +204,10 @@ class Connection extends EventEmitter implements ConnectionInterface
      */
     public function connect($callback)
     {
+        if ($this->state !== self::STATE_INIT) {
+            throw new Exception('Connection not in idle state');
+        }
+
         $this->state = self::STATE_CONNECTING;
         $options     = $this->options;
         $streamRef   = $this->stream;
@@ -285,7 +289,7 @@ class Connection extends EventEmitter implements ConnectionInterface
         } elseif ($this->state >= self::STATE_CONNECTING && $this->state <= self::STATE_AUTHENTICATED) {
             return $this->executor->enqueue($command);
         } else {
-            throw new Exception("Cann't send command");
+            throw new Exception("Can't send command");
         }
     }
 }

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -33,6 +33,7 @@ interface ConnectionInterface
      *  function (QueryCommand $cmd, ConnectionInterface $conn): void
      *
      * @return QueryCommand|null Return QueryCommand if $callback not specified.
+     * @throws Exception if the connection is not initialized or already closed/closing
      */
     public function query($sql, $callback = null, $params = null);
 
@@ -46,6 +47,7 @@ interface ConnectionInterface
      *  function (\Exception $e = null, ConnectionInterface $conn): void
      *
      * @return void
+     * @throws Exception if the connection is not initialized or already closed/closing
      */
     public function ping($callback);
 
@@ -55,6 +57,7 @@ interface ConnectionInterface
      * @param string $dbname Database name.
      *
      * @return QueryCommand
+     * @throws Exception if the connection is not initialized or already closed/closing
      */
     public function selectDb($dbname);
 
@@ -126,6 +129,7 @@ interface ConnectionInterface
      *  function (ConnectionInterface $conn): void
      *
      * @return void
+     * @throws Exception if the connection is not initialized or already closed/closing
      */
     public function close($callback = null);
 
@@ -138,7 +142,12 @@ interface ConnectionInterface
      *
      *  function (\Exception $e = null, ConnectionInterface $conn): void
      *
+     * This method should be invoked once after the `Connection` is initialized.
+     * You can queue additional `query()`, `ping()` and `close()` calls after
+     * invoking this method without having to await its resolution first.
+     *
      * @return void
+     * @throws Exception if the connection is already initialized, i.e. it MUST NOT be called more than once.
      */
     public function connect($callback);
 }


### PR DESCRIPTION
This PR ensures consistent connect() behavior for all connection states. This implies that calling `connect()` in an invalid state (i.e. calling it more than once) will not throw an exception and is now in line with the other methods.

The code change is rather trivial, most of this changeset is about tests to ensure consistent behavior for the current API and documentation for this.

Resolves / closes #6