### PR TITLE
Fix parameter binding if query contains question marks

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -97,14 +97,18 @@ class Connection extends EventEmitter implements ConnectionInterface
         array_shift($args); // Remove $sql parameter.
 
         if (!is_callable($callback)) {
-            $query->bindParamsFromArray($args);
+            if ($args) {
+                $query->bindParamsFromArray($args);
+            }
 
             return $this->_doCommand($command);
         }
 
         array_shift($args); // Remove $callback
 
-        $query->bindParamsFromArray($args);
+        if ($args) {
+            $query->bindParamsFromArray($args);
+        }
         $this->_doCommand($command);
 
         $command->on('results', function ($rows, $command) use ($callback) {

--- a/src/Query.php
+++ b/src/Query.php
@@ -26,7 +26,7 @@ class Query
 
     public function __construct($sql)
     {
-        $this->sql = $sql;
+        $this->sql = $this->builtSql = $sql;
     }
 
     /**

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -26,6 +26,41 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         */
     }
 
+    public function testGetSqlReturnsQuestionMarkReplacedWhenBound()
+    {
+        $query = new Query('select ?');
+        $sql   = $query->bindParams('hello')->getSql();
+        $this->assertEquals("select 'hello'", $sql);
+    }
+
+    public function testGetSqlReturnsQuestionMarkReplacedWhenBoundFromLastCall()
+    {
+        $query = new Query('select ?');
+        $sql   = $query->bindParams('foo')->bindParams('bar')->getSql();
+        $this->assertEquals("select 'bar'", $sql);
+    }
+
+    public function testGetSqlReturnsQuestionMarkReplacedWithNullValueWhenBound()
+    {
+        $query = new Query('select ?');
+        $sql   = $query->bindParams(null)->getSql();
+        $this->assertEquals("select NULL", $sql);
+    }
+
+    public function testGetSqlReturnsQuestionMarkReplacedFromBoundWhenBound()
+    {
+        $query = new Query('select CONCAT(?, ?)');
+        $sql   = $query->bindParams('hello??', 'world??')->getSql();
+        $this->assertEquals("select CONCAT('hello??', 'world??')", $sql);
+    }
+
+    public function testGetSqlReturnsQuestionMarksAsIsWhenNotBound()
+    {
+        $query = new Query('select "hello?"');
+        $sql   = $query->getSql();
+        $this->assertEquals("select \"hello?\"", $sql);
+    }
+
     public function testEscapeChars()
     {
         $query = new Query('');

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -4,6 +4,63 @@ namespace React\Tests\MySQL;
 
 class ResultQueryTest extends BaseTestCase
 {
+    public function testSelectStaticText()
+    {
+        $loop = \React\EventLoop\Factory::create();
+
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
+        $connection->connect(function () {});
+
+        $connection->query('select \'foo\'', function ($command, $conn) {
+            $this->assertEquals(false, $command->hasError());
+            $this->assertCount(1, $command->resultRows);
+            $this->assertCount(1, $command->resultRows[0]);
+            $this->assertEquals('foo', reset($command->resultRows[0]));
+            $this->assertInstanceOf('React\MySQL\Connection', $conn);
+        });
+
+        $connection->close();
+        $loop->run();
+    }
+
+    public function testSelectStaticTextWithParamBinding()
+    {
+        $loop = \React\EventLoop\Factory::create();
+
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
+        $connection->connect(function () {});
+
+        $connection->query('select ?', function ($command, $conn) {
+            $this->assertEquals(false, $command->hasError());
+            $this->assertCount(1, $command->resultRows);
+            $this->assertCount(1, $command->resultRows[0]);
+            $this->assertEquals('foo', reset($command->resultRows[0]));
+            $this->assertInstanceOf('React\MySQL\Connection', $conn);
+        }, 'foo');
+
+        $connection->close();
+        $loop->run();
+    }
+
+    public function testSelectStaticTextWithQuestionMark()
+    {
+        $loop = \React\EventLoop\Factory::create();
+
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
+        $connection->connect(function () {});
+
+        $connection->query('select \'hello?\'', function ($command, $conn) {
+            $this->assertEquals(false, $command->hasError());
+            $this->assertCount(1, $command->resultRows);
+            $this->assertCount(1, $command->resultRows[0]);
+            $this->assertEquals('hello?', reset($command->resultRows[0]));
+            $this->assertInstanceOf('React\MySQL\Connection', $conn);
+        });
+
+        $connection->close();
+        $loop->run();
+    }
+
     public function testSimpleSelect()
     {
         $loop = \React\EventLoop\Factory::create();


### PR DESCRIPTION
This PR ensures that the `Query` class will only try to replace question marks in the given SQL string if bind params have actually been passed explicitly. If no bind params have been passed, it will no longer try to replace any params and thus no longer complain about missing params.

Resolves / closes #15 
Builds on top of #39