### PR TITLE
Fix reading empty rows containing only empty string columns 

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class BaseTestCase extends TestCase
 {
-    protected function getConnectionOptions()
+    protected function getConnectionOptions($debug = false)
     {
         // can be controlled through ENV or by changing defaults in phpunit.xml
         return [
@@ -15,7 +15,7 @@ class BaseTestCase extends TestCase
             'dbname' => getenv('DB_DBNAME'),
             'user'   => getenv('DB_USER'),
             'passwd' => getenv('DB_PASSWD'),
-        ];
+        ] + ($debug ? ['debug' => true] : []);
     }
 
     protected function getDataTable()

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -18,7 +18,7 @@ class ResultQueryTest extends BaseTestCase
 
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
-            $this->assertEquals('foo', reset($command->resultRows[0]));
+            $this->assertSame('foo', reset($command->resultRows[0]));
 
             $this->assertInstanceOf('React\MySQL\Connection', $conn);
         });
@@ -56,10 +56,6 @@ class ResultQueryTest extends BaseTestCase
      */
     public function testSelectStaticValueWillBeReturnedAsIs($value)
     {
-        if ($value === '') {
-            $this->markTestIncomplete();
-        }
-
         $loop = \React\EventLoop\Factory::create();
 
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
@@ -301,8 +297,6 @@ class ResultQueryTest extends BaseTestCase
 
     public function testSelectStaticTextTwoRowsWithEmptyRow()
     {
-        $this->markTestIncomplete();
-
         $loop = \React\EventLoop\Factory::create();
 
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
@@ -369,7 +363,7 @@ class ResultQueryTest extends BaseTestCase
         $loop->run();
     }
 
-    public function testSelectStaticTextTwoColumnsWithEmptyColumn()
+    public function testSelectStaticTextTwoColumnsWithOneEmptyColumn()
     {
         $loop = \React\EventLoop\Factory::create();
 
@@ -384,6 +378,31 @@ class ResultQueryTest extends BaseTestCase
 
             $this->assertSame('foo', reset($command->resultRows[0]));
             $this->assertSame('', next($command->resultRows[0]));
+
+            $this->assertInstanceOf('React\MySQL\Connection', $conn);
+        });
+
+        $connection->close();
+        $loop->run();
+    }
+
+    public function testSelectStaticTextTwoColumnsWithBothEmpty()
+    {
+        $loop = \React\EventLoop\Factory::create();
+
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
+        $connection->connect(function () {});
+
+        $connection->query('select \'\' as `first`, \'\' as `second`', function ($command, $conn) {
+            $this->assertEquals(false, $command->hasError());
+
+            $this->assertCount(1, $command->resultRows);
+            $this->assertCount(2, $command->resultRows[0]);
+            $this->assertSame(array('', ''), array_values($command->resultRows[0]));
+
+            $this->assertCount(2, $command->resultFields);
+            $this->assertSame(Constants::FIELD_TYPE_VAR_STRING, $command->resultFields[0]['type']);
+            $this->assertSame(Constants::FIELD_TYPE_VAR_STRING, $command->resultFields[1]['type']);
 
             $this->assertInstanceOf('React\MySQL\Connection', $conn);
         });

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -2,6 +2,8 @@
 
 namespace React\Tests\MySQL;
 
+use React\MySQL\Protocal\Constants;
+
 class ResultQueryTest extends BaseTestCase
 {
     public function testSelectStaticText()
@@ -13,9 +15,11 @@ class ResultQueryTest extends BaseTestCase
 
         $connection->query('select \'foo\'', function ($command, $conn) {
             $this->assertEquals(false, $command->hasError());
+
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertEquals('foo', reset($command->resultRows[0]));
+
             $this->assertInstanceOf('React\MySQL\Connection', $conn);
         });
 
@@ -23,20 +27,79 @@ class ResultQueryTest extends BaseTestCase
         $loop->run();
     }
 
-    public function testSelectStaticTextWithParamBinding()
+    public function provideValuesThatWillBeReturnedAsIs()
+    {
+        return array_map(function ($e) { return array($e); }, array(
+            'foo',
+            'hello?',
+            'FööBär',
+            'pile of 💩',
+            '<>&--\\\'";',
+            "\0\1\2\3\4\5\6\7\8\xff",
+            '',
+            null
+        ));
+    }
+
+    public function provideValuesThatWillBeConvertedToString()
+    {
+        return array(
+            array(1, '1'),
+            array(1.5, '1.5'),
+            array(true, '1'),
+            array(false, '0')
+        );
+    }
+
+    /**
+     * @dataProvider provideValuesThatWillBeReturnedAsIs
+     */
+    public function testSelectStaticValueWillBeReturnedAsIs($value)
+    {
+        if ($value === '') {
+            $this->markTestIncomplete();
+        }
+
+        $loop = \React\EventLoop\Factory::create();
+
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
+        $connection->connect(function () {});
+
+        $expected = $value;
+
+        $connection->query('select ?', function ($command, $conn) use ($expected) {
+            $this->assertEquals(false, $command->hasError());
+
+            $this->assertCount(1, $command->resultRows);
+            $this->assertCount(1, $command->resultRows[0]);
+            $this->assertSame($expected, reset($command->resultRows[0]));
+
+            $this->assertInstanceOf('React\MySQL\Connection', $conn);
+        }, $value);
+
+        $connection->close();
+        $loop->run();
+    }
+
+    /**
+     * @dataProvider provideValuesThatWillBeConvertedToString
+     */
+    public function testSelectStaticValueWillBeConvertedToString($value, $expected)
     {
         $loop = \React\EventLoop\Factory::create();
 
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query('select ?', function ($command, $conn) {
+        $connection->query('select ?', function ($command, $conn) use ($expected) {
             $this->assertEquals(false, $command->hasError());
+
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
-            $this->assertEquals('foo', reset($command->resultRows[0]));
+            $this->assertSame($expected, reset($command->resultRows[0]));
+
             $this->assertInstanceOf('React\MySQL\Connection', $conn);
-        }, 'foo');
+        }, $value);
 
         $connection->close();
         $loop->run();
@@ -51,9 +114,11 @@ class ResultQueryTest extends BaseTestCase
 
         $connection->query('select \'hello?\'', function ($command, $conn) {
             $this->assertEquals(false, $command->hasError());
+
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertEquals('hello?', reset($command->resultRows[0]));
+
             $this->assertInstanceOf('React\MySQL\Connection', $conn);
         });
 
@@ -61,7 +126,7 @@ class ResultQueryTest extends BaseTestCase
         $loop->run();
     }
 
-    public function testSelectLongStaticTextWithProperType()
+    public function testSelectLongStaticTextHasTypeStringWithValidLength()
     {
         $loop = \React\EventLoop\Factory::create();
 
@@ -72,10 +137,282 @@ class ResultQueryTest extends BaseTestCase
 
         $connection->query('SELECT ?', function ($command, $conn) use ($length) {
             $this->assertEquals(false, $command->hasError());
+
             $this->assertCount(1, $command->resultFields);
             $this->assertEquals($length * 3, $command->resultFields[0]['length']);
+            $this->assertSame(Constants::FIELD_TYPE_VAR_STRING, $command->resultFields[0]['type']);
+
             $this->assertInstanceOf('React\MySQL\Connection', $conn);
         }, str_repeat('.', $length));
+
+        $connection->close();
+        $loop->run();
+    }
+
+    public function testSelectStaticTextWithEmptyLabel()
+    {
+        $loop = \React\EventLoop\Factory::create();
+
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
+        $connection->connect(function () {});
+
+        $connection->query('select \'foo\' as ``', function ($command, $conn) {
+            $this->assertEquals(false, $command->hasError());
+
+            $this->assertCount(1, $command->resultRows);
+            $this->assertCount(1, $command->resultRows[0]);
+            $this->assertSame('foo', reset($command->resultRows[0]));
+            $this->assertSame('', key($command->resultRows[0]));
+
+            $this->assertCount(1, $command->resultFields);
+            $this->assertSame('', $command->resultFields[0]['name']);
+
+            $this->assertInstanceOf('React\MySQL\Connection', $conn);
+        });
+
+        $connection->close();
+        $loop->run();
+    }
+
+    public function testSelectStaticNullHasTypeNull()
+    {
+        $loop = \React\EventLoop\Factory::create();
+
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
+        $connection->connect(function () {});
+
+        $connection->query('select null', function ($command, $conn) {
+            $this->assertEquals(false, $command->hasError());
+
+            $this->assertCount(1, $command->resultRows);
+            $this->assertCount(1, $command->resultRows[0]);
+            $this->assertNull(reset($command->resultRows[0]));
+
+            $this->assertCount(1, $command->resultFields);
+            $this->assertSame(Constants::FIELD_TYPE_NULL, $command->resultFields[0]['type']);
+
+            $this->assertInstanceOf('React\MySQL\Connection', $conn);
+        });
+
+        $connection->close();
+        $loop->run();
+    }
+
+    public function testSelectStaticTextTwoRows()
+    {
+        $loop = \React\EventLoop\Factory::create();
+
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
+        $connection->connect(function () {});
+
+        $connection->query('select "foo" UNION select "bar"', function ($command, $conn) {
+            $this->assertEquals(false, $command->hasError());
+
+            $this->assertCount(2, $command->resultRows);
+            $this->assertCount(1, $command->resultRows[0]);
+
+            $this->assertSame('foo', reset($command->resultRows[0]));
+            $this->assertSame('bar', reset($command->resultRows[1]));
+
+            $this->assertInstanceOf('React\MySQL\Connection', $conn);
+        });
+
+        $connection->close();
+        $loop->run();
+    }
+
+    public function testSelectStaticTextTwoRowsWithNullHasTypeString()
+    {
+        $loop = \React\EventLoop\Factory::create();
+
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
+        $connection->connect(function () {});
+
+        $connection->query('select "foo" UNION select null', function ($command, $conn) {
+            $this->assertEquals(false, $command->hasError());
+
+            $this->assertCount(2, $command->resultRows);
+            $this->assertCount(1, $command->resultRows[0]);
+
+            $this->assertSame('foo', reset($command->resultRows[0]));
+            $this->assertNull(reset($command->resultRows[1]));
+
+            $this->assertCount(1, $command->resultFields);
+            $this->assertSame(Constants::FIELD_TYPE_VAR_STRING, $command->resultFields[0]['type']);
+
+            $this->assertInstanceOf('React\MySQL\Connection', $conn);
+        });
+
+        $connection->close();
+        $loop->run();
+    }
+
+    public function testSelectStaticIntegerTwoRowsWithNullHasTypeLongButReturnsIntAsString()
+    {
+        $loop = \React\EventLoop\Factory::create();
+
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
+        $connection->connect(function () {});
+
+        $connection->query('select 0 UNION select null', function ($command, $conn) {
+            $this->assertEquals(false, $command->hasError());
+
+            $this->assertCount(2, $command->resultRows);
+            $this->assertCount(1, $command->resultRows[0]);
+
+            $this->assertSame('0', reset($command->resultRows[0]));
+            $this->assertNull(reset($command->resultRows[1]));
+
+            $this->assertCount(1, $command->resultFields);
+            $this->assertSame(Constants::FIELD_TYPE_LONGLONG, $command->resultFields[0]['type']);
+
+            $this->assertInstanceOf('React\MySQL\Connection', $conn);
+        });
+
+        $connection->close();
+        $loop->run();
+    }
+
+    public function testSelectStaticTextTwoRowsWithIntegerHasTypeString()
+    {
+        $loop = \React\EventLoop\Factory::create();
+
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
+        $connection->connect(function () {});
+
+        $connection->query('select "foo" UNION select 1', function ($command, $conn) {
+            $this->assertEquals(false, $command->hasError());
+
+            $this->assertCount(2, $command->resultRows);
+            $this->assertCount(1, $command->resultRows[0]);
+
+            $this->assertSame('foo', reset($command->resultRows[0]));
+            $this->assertSame('1', reset($command->resultRows[1]));
+
+            $this->assertCount(1, $command->resultFields);
+            $this->assertSame(Constants::FIELD_TYPE_VAR_STRING, $command->resultFields[0]['type']);
+
+            $this->assertInstanceOf('React\MySQL\Connection', $conn);
+        });
+
+        $connection->close();
+        $loop->run();
+    }
+
+    public function testSelectStaticTextTwoRowsWithEmptyRow()
+    {
+        $this->markTestIncomplete();
+
+        $loop = \React\EventLoop\Factory::create();
+
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
+        $connection->connect(function () {});
+
+        $connection->query('select "foo" UNION select ""', function ($command, $conn) {
+            $this->assertEquals(false, $command->hasError());
+
+            $this->assertCount(2, $command->resultRows);
+            $this->assertCount(1, $command->resultRows[0]);
+
+            $this->assertSame('foo', reset($command->resultRows[0]));
+            $this->assertSame('', reset($command->resultRows[1]));
+
+            $this->assertInstanceOf('React\MySQL\Connection', $conn);
+        });
+
+        $connection->close();
+        $loop->run();
+    }
+
+    public function testSelectStaticTextNoRows()
+    {
+        $loop = \React\EventLoop\Factory::create();
+
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
+        $connection->connect(function () {});
+
+        $connection->query('select "foo" LIMIT 0', function ($command, $conn) {
+            $this->assertEquals(false, $command->hasError());
+
+            $this->assertCount(0, $command->resultRows);
+
+            $this->assertCount(1, $command->resultFields);
+            $this->assertSame('foo', $command->resultFields[0]['name']);
+
+            $this->assertInstanceOf('React\MySQL\Connection', $conn);
+        });
+
+        $connection->close();
+        $loop->run();
+    }
+
+    public function testSelectStaticTextTwoColumns()
+    {
+        $loop = \React\EventLoop\Factory::create();
+
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
+        $connection->connect(function () {});
+
+        $connection->query('select "foo","bar"', function ($command, $conn) {
+            $this->assertEquals(false, $command->hasError());
+
+            $this->assertCount(1, $command->resultRows);
+            $this->assertCount(2, $command->resultRows[0]);
+
+            $this->assertSame('foo', reset($command->resultRows[0]));
+            $this->assertSame('bar', next($command->resultRows[0]));
+
+            $this->assertInstanceOf('React\MySQL\Connection', $conn);
+        });
+
+        $connection->close();
+        $loop->run();
+    }
+
+    public function testSelectStaticTextTwoColumnsWithEmptyColumn()
+    {
+        $loop = \React\EventLoop\Factory::create();
+
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
+        $connection->connect(function () {});
+
+        $connection->query('select "foo",""', function ($command, $conn) {
+            $this->assertEquals(false, $command->hasError());
+
+            $this->assertCount(1, $command->resultRows);
+            $this->assertCount(2, $command->resultRows[0]);
+
+            $this->assertSame('foo', reset($command->resultRows[0]));
+            $this->assertSame('', next($command->resultRows[0]));
+
+            $this->assertInstanceOf('React\MySQL\Connection', $conn);
+        });
+
+        $connection->close();
+        $loop->run();
+    }
+
+    public function testSelectStaticTextTwoColumnsWithSameNameOverwritesValue()
+    {
+        $loop = \React\EventLoop\Factory::create();
+
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
+        $connection->connect(function () {});
+
+        $connection->query('select "foo" as `col`,"bar" as `col`', function ($command, $conn) {
+            $this->assertEquals(false, $command->hasError());
+
+            $this->assertCount(1, $command->resultRows);
+            $this->assertCount(1, $command->resultRows[0]);
+
+            $this->assertSame('bar', reset($command->resultRows[0]));
+
+            $this->assertCount(2, $command->resultFields);
+            $this->assertSame('col', $command->resultFields[0]['name']);
+            $this->assertSame('col', $command->resultFields[1]['name']);
+
+            $this->assertInstanceOf('React\MySQL\Connection', $conn);
+        });
 
         $connection->close();
         $loop->run();


### PR DESCRIPTION
This PR first adds a number of test cases to very what kind of values can be processed and subsequently fixes reading empty rows containing only empty string columns.

Previously, the protocol parser would fail for all result sets that contain a single row that consists of only empty string values, for example:

```
SELECT ""
SELECT 1 UNION SELECT ""
SELECT "", ""
```

Resolves / closes #28 