### PR TITLE
Do not support multiple statements for security and API reasons

### DIFF
--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -32,6 +32,11 @@ interface ConnectionInterface
      *
      *  function (QueryCommand $cmd, ConnectionInterface $conn): void
      *
+     * The given `$sql` parameter MUST contain a single statement. Support
+     * for multiple statements is disabled for security reasons because it
+     * could allow for possible SQL injection attacks and this API is not
+     * suited for exposing multiple possible results.
+     *
      * @return QueryCommand|null Return QueryCommand if $callback not specified.
      * @throws Exception if the connection is not initialized or already closed/closing
      */

--- a/src/Protocal/Parser.php
+++ b/src/Protocal/Parser.php
@@ -406,8 +406,6 @@ field:
                 Constants::CLIENT_INTERACTIVE |
                 Constants::CLIENT_TRANSACTIONS |
                 Constants::CLIENT_SECURE_CONNECTION |
-                Constants::CLIENT_MULTI_RESULTS |
-                Constants::CLIENT_MULTI_STATEMENTS |
                 Constants::CLIENT_CONNECT_WITH_DB;
 
         $packet = pack('VVc', $clientFlags, $this->maxPacketSize, $this->charsetNumber)

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -104,7 +104,7 @@ class ResultQueryTest extends BaseTestCase
         $loop->run();
     }
 
-    public function testInvalidSelect()
+    public function testInvalidSelectShouldFail()
     {
         $loop = \React\EventLoop\Factory::create();
 
@@ -116,6 +116,22 @@ class ResultQueryTest extends BaseTestCase
         $connection->query('select * from invalid_table', function ($command, $conn) use ($db) {
             $this->assertEquals(true, $command->hasError());
             $this->assertEquals("Table '$db.invalid_table' doesn't exist", $command->getError()->getMessage());
+        });
+
+        $connection->close();
+        $loop->run();
+    }
+
+    public function testInvalidMultiStatementsShouldFailToPreventSqlInjections()
+    {
+        $loop = \React\EventLoop\Factory::create();
+
+        $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
+        $connection->connect(function () {});
+
+        $connection->query('select 1;select 2;', function ($command, $conn) {
+            $this->assertEquals(true, $command->hasError());
+            $this->assertContains("You have an error in your SQL syntax", $command->getError()->getMessage());
         });
 
         $connection->close();


### PR DESCRIPTION
This PR disables the (broken) support for multiple statements for security and API reasons. Sending multiple statements as a single query could allow for possible SQL injection attacks if the input is not properly escaped. Also, the current API has no (sane) way of exposing multiple results (such as multiple independent result sets).

I do not consider this to be a BC break because the current API has no sane way of exposing multiple results in the first place and the test suite does not contain any mention of this. This PR adds a test to ensure queries with multiple statements are now properly rejected.

We will likely look into this again for a future version, once the current API issues have been worked out. Possible future implementation ideas: Exposing numbered sets à la https://github.com/mysqljs/mysql#multiple-statement-queries or discarding additional sets à la https://github.com/go-sql-driver/mysql/pull/411