### PR TITLE
Reject pending commands if connection is closed

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -138,7 +138,7 @@ abstract class Command extends EventEmitter implements CommandInterface
      * @param integer $cmd
      * @param string  $q
      */
-    public function __construct(Connection $connection)
+    public function __construct(ConnectionInterface $connection)
     {
         $this->connection = $connection;
     }

--- a/src/Protocal/Parser.php
+++ b/src/Protocal/Parser.php
@@ -379,6 +379,12 @@ field:
 
             if ($command->equals(Command::QUIT)) {
                 $command->emit('success');
+            } else {
+                $command->emit('error', array(
+                    new \RuntimeException('Connection lost'),
+                    $command,
+                    $command->getConnection()
+                ));
             }
         }
     }

--- a/src/Protocal/Parser.php
+++ b/src/Protocal/Parser.php
@@ -25,7 +25,20 @@ class Parser extends EventEmitter
     protected $dbname   = '';
 
     /**
-     * @var \React\MySQL\Command
+     * Keeps a reference to the command that is currently being processed.
+     *
+     * The MySQL protocol is inherently sequential, the pending commands will be
+     * stored in an `Executor` queue.
+     *
+     * The MySQL protocol communication starts with the server sending a
+     * handshake message, so the current command will be `null` until it's our
+     * turn.
+     *
+     * Similarly, when one command is finished, it will continue processing the
+     * next command from the `Executor` queue. If no command is outstanding,
+     * this will be reset to the `null` state.
+     *
+     * @var \React\MySQL\Command|null
      */
     protected $currCommand;
 
@@ -80,13 +93,20 @@ class Parser extends EventEmitter
      */
     protected $executor;
 
+    /**
+     * @deprecated
+     * @see self::$currCommand
+     */
     protected $queue;
 
     public function __construct($stream, $executor)
     {
         $this->stream   = $stream;
         $this->executor = $executor;
-        $this->queue    = new \SplQueue($this);
+
+        // @deprecated unused, exists for BC only.
+        $this->queue    = new \SplQueue();
+
         $executor->on('new', array($this, 'handleNewCommand'));
     }
 
@@ -98,7 +118,7 @@ class Parser extends EventEmitter
 
     public function handleNewCommand()
     {
-        if ($this->queue->count() <= 0) {
+        if ($this->currCommand === null) {
             $this->nextRequest();
         }
     }
@@ -191,8 +211,8 @@ field:
                 $this->errmsg  = $this->read($this->pctSize - $len + $this->length());
                 $this->debug(sprintf("Error Packet:%d %s\n", $this->errno, $this->errmsg));
 
-                $this->nextRequest();
                 $this->onError();
+                $this->nextRequest();
             } elseif ($fieldCount === 0x00) {
                 // Empty OK Packet
                 $this->debug('Ok Packet');
@@ -238,8 +258,8 @@ field:
                     // finalize this result set (all rows completed)
                     $this->debug('result done');
 
-                    $this->nextRequest();
                     $this->onResultDone();
+                    $this->nextRequest();
                 } else {
                     // move to next part of result set (header->field->row)
                     ++$this->rsState;
@@ -298,14 +318,15 @@ field:
     {
         // $this->debug('row data: ' . json_encode($row));
         $this->resultRows[] = $row;
-        $command = $this->queue->dequeue();
+        $command = $this->currCommand;
         $command->emit('result', array($row, $command, $command->getConnection()));
-        $this->queue->unshift($command);
     }
 
     protected function onError()
     {
-        $command = $this->queue->dequeue();
+        $command = $this->currCommand;
+        $this->currCommand = null;
+
         $error = new Exception($this->errmsg, $this->errno);
         $command->setError($error);
         $command->emit('error', array($error, $command, $command->getConnection()));
@@ -315,7 +336,9 @@ field:
 
     protected function onResultDone()
     {
-        $command =  $this->queue->dequeue();
+        $command = $this->currCommand;
+        $this->currCommand = null;
+
         $command->resultRows   = $this->resultRows;
         $command->resultFields = $this->resultFields;
         $command->emit('results', array($this->resultRows, $command, $command->getConnection()));
@@ -327,7 +350,9 @@ field:
 
     protected function onSuccess()
     {
-        $command = $this->queue->dequeue();
+        $command = $this->currCommand;
+        $this->currCommand = null;
+
         if ($command->equals(Command::QUERY)) {
             $command->affectedRows = $this->affectedRows;
             $command->insertId     = $this->insertId;
@@ -339,15 +364,19 @@ field:
 
     protected function onAuthenticated()
     {
-        $command = $this->queue->dequeue();
+        $command = $this->currCommand;
+        $this->currCommand = null;
+
         $command->emit('authenticated', array($this->connectOptions));
     }
 
     protected function onClose()
     {
         $this->emit('close');
-        if ($this->queue->count()) {
-            $command = $this->queue->dequeue();
+        if ($this->currCommand !== null) {
+            $command = $this->currCommand;
+            $this->currCommand = null;
+
             if ($command->equals(Command::QUIT)) {
                 $command->emit('success');
             }
@@ -525,9 +554,11 @@ field:
         if (!$isHandshake && $this->phase != self::PHASE_HANDSHAKED) {
             return false;
         }
+
         if (!$this->executor->isIdle()) {
             $command = $this->executor->dequeue();
-            $this->queue->enqueue($command);
+            $this->currCommand = $command;
+
             if ($command->equals(Command::INIT_AUTHENTICATE)) {
                 $this->authenticate();
             } else {

--- a/tests/Protocal/ParserTest.php
+++ b/tests/Protocal/ParserTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace React\Tests\MySQL\Protocal;
+
+use React\MySQL\Commands\QueryCommand;
+use React\MySQL\Executor;
+use React\MySQL\Protocal\Parser;
+use React\Stream\ThroughStream;
+use React\Tests\MySQL\BaseTestCase;
+
+class ParserTest extends BaseTestCase
+{
+    public function testClosingStreamEmitsCloseEvent()
+    {
+        $stream = new ThroughStream();
+        $connection = $this->getMockBuilder('React\MySQL\ConnectionInterface')->disableOriginalConstructor()->getMock();
+        $executor = new Executor($connection);
+
+        $parser = new Parser($stream, $executor);
+        $parser->start();
+
+        $parser->on('close', $this->expectCallableOnce());
+
+        $stream->close();
+    }
+
+    public function testClosingStreamEmitsErrorForCurrentCommand()
+    {
+        $stream = new ThroughStream();
+        $connection = $this->getMockBuilder('React\MySQL\ConnectionInterface')->disableOriginalConstructor()->getMock();
+        $executor = new Executor($connection);
+
+        $parser = new Parser($stream, $executor);
+        $parser->start();
+
+        $command = new QueryCommand($connection);
+        $command->on('error', $this->expectCallableOnce());
+
+        // hack to inject command as current command
+        $parser->setOptions(array('currCommand' => $command));
+
+        $stream->close();
+    }
+}


### PR DESCRIPTION
This PR ensures that all outstanding commands will be rejected if the connection is closed.

As a first step, this PR performs a minor refactoring to avoid accessing an internal queue that only ever has a maximum of one single command anyway. This is not a BC break because its outside behavior is preserved (tests are not affected). Additionally, it ensures that the current command and any queued ones will be properly rejected with an `error` event the connection is closed.

Resolves / closes #44