### PR TITLE
Mark all protocol logic classes as internal and move to new Io namespace

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -2,6 +2,8 @@
 
 namespace React\MySQL;
 
+use React\MySQL\Io\EventEmitter;
+
 abstract class Command extends EventEmitter implements CommandInterface
 {
     /**

--- a/src/Commands/QueryCommand.php
+++ b/src/Commands/QueryCommand.php
@@ -3,7 +3,7 @@
 namespace React\MySQL\Commands;
 
 use React\MySQL\Command;
-use React\MySQL\Query;
+use React\MySQL\Io\Query;
 
 class QueryCommand extends Command
 {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -10,6 +10,10 @@ use React\MySQL\Commands\AuthenticateCommand;
 use React\MySQL\Commands\PingCommand;
 use React\MySQL\Commands\QueryCommand;
 use React\MySQL\Commands\QuitCommand;
+use React\MySQL\Io\EventEmitter;
+use React\MySQL\Io\Executor;
+use React\MySQL\Io\Parser;
+use React\MySQL\Io\Query;
 
 /**
  * Class Connection
@@ -61,7 +65,7 @@ class Connection extends EventEmitter implements ConnectionInterface
     private $stream;
 
     /**
-     * @var Protocal\Parser
+     * @var Parser
      */
     public $parser;
 
@@ -234,7 +238,7 @@ class Connection extends EventEmitter implements ConnectionInterface
                 $stream->on('error', [$this, 'handleConnectionError']);
                 $stream->on('close', [$this, 'handleConnectionClosed']);
 
-                $parser = $this->parser = new Protocal\Parser($stream, $this->executor);
+                $parser = $this->parser = new Parser($stream, $this->executor);
 
                 $parser->setOptions($options);
 

--- a/src/Io/Binary.php
+++ b/src/Io/Binary.php
@@ -1,7 +1,10 @@
 <?php
 
-namespace React\MySQL\Protocal;
+namespace React\MySQL\Io;
 
+/**
+ * @internal
+ */
 class Binary
 {
     /**

--- a/src/Io/Constants.php
+++ b/src/Io/Constants.php
@@ -1,7 +1,10 @@
 <?php
 
-namespace React\MySQL\Protocal;
+namespace React\MySQL\Io;
 
+/**
+ * @internal
+ */
 class Constants
 {
     /**

--- a/src/Io/EventEmitter.php
+++ b/src/Io/EventEmitter.php
@@ -1,7 +1,10 @@
 <?php
 
-namespace React\MySQL;
+namespace React\MySQL\Io;
 
+/**
+ * @internal
+ */
 class EventEmitter extends \Evenement\EventEmitter
 {
     public function on($event, callable $listener)

--- a/src/Io/Executor.php
+++ b/src/Io/Executor.php
@@ -1,7 +1,10 @@
 <?php
 
-namespace React\MySQL;
+namespace React\MySQL\Io;
 
+/**
+ * @internal
+ */
 class Executor extends EventEmitter
 {
     private $client;

--- a/src/Io/Parser.php
+++ b/src/Io/Parser.php
@@ -1,12 +1,15 @@
 <?php
 
-namespace React\MySQL\Protocal;
+namespace React\MySQL\Io;
 
-use Evenement\EventEmitter;
 use React\MySQL\Exception;
 use React\MySQL\Command;
+use React\Stream\DuplexStreamInterface;
 
-class Parser extends EventEmitter
+/**
+ * @internal
+ */
+class Parser extends \Evenement\EventEmitter
 {
     const PHASE_GOT_INIT   = 1;
     const PHASE_AUTH_SENT  = 2;
@@ -85,11 +88,11 @@ class Parser extends EventEmitter
     protected $connectOptions;
 
     /**
-     * @var \React\Stream\Stream
+     * @var \React\Stream\DuplexStreamInterface
      */
     protected $stream;
     /**
-     * @var \React\MySQL\Executor
+     * @var Executor
      */
     protected $executor;
 
@@ -99,7 +102,7 @@ class Parser extends EventEmitter
      */
     protected $queue;
 
-    public function __construct($stream, $executor)
+    public function __construct(DuplexStreamInterface $stream, Executor $executor)
     {
         $this->stream   = $stream;
         $this->executor = $executor;

--- a/src/Io/Query.php
+++ b/src/Io/Query.php
@@ -1,7 +1,10 @@
 <?php
 
-namespace React\MySQL;
+namespace React\MySQL\Io;
 
+/**
+ * @internal
+ */
 class Query
 {
     private $sql;
@@ -33,7 +36,7 @@ class Query
      * Binding params for the query, mutiple arguments support.
      *
      * @param  mixed              $param
-     * @return \React\MySQL\Query
+     * @return self
      */
     public function bindParams()
     {
@@ -55,7 +58,7 @@ class Query
      * Binding params for the query, mutiple arguments support.
      *
      * @param  mixed              $param
-     * @return \React\MySQL\Query
+     * @return self
      *                                  @deprecated
      */
     public function params()

--- a/tests/Io/ParserTest.php
+++ b/tests/Io/ParserTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace React\Tests\MySQL\Protocal;
+namespace React\Tests\MySQL\Io;
 
 use React\MySQL\Commands\QueryCommand;
-use React\MySQL\Executor;
-use React\MySQL\Protocal\Parser;
+use React\MySQL\Io\Executor;
+use React\MySQL\Io\Parser;
 use React\Stream\ThroughStream;
 use React\Tests\MySQL\BaseTestCase;
 

--- a/tests/Io/QueryTest.php
+++ b/tests/Io/QueryTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace React\Tests\MySQL;
+namespace React\Tests\MySQL\Io;
 
-use React\MySQL\Query;
+use React\MySQL\Io\Query;
 
 class QueryTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -2,7 +2,7 @@
 
 namespace React\Tests\MySQL;
 
-use React\MySQL\Protocal\Constants;
+use React\MySQL\Io\Constants;
 
 class ResultQueryTest extends BaseTestCase
 {


### PR DESCRIPTION
As a first step for the upcoming v0.4.0 release, this simple PR marks all internal classes as `@internal` and moves them to a new `React\MySQL\Io` namespace.

This is technically a BC break because consumers could potentially rely on these classes, but there's no reasons to believe this is actually done in the wild and as such should not affect "normal" usage as described in our documentation. Marking these classes as `@internal` allows us to perform some (significant) changes to them without causing additional BC breaks, as consumers are now explicitly discouraged from using them in their code.