### PR TITLE
Add queryStream() method to stream result set rows and remove undocumented "results" event

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ It is written in pure PHP and does not require any extensions.
 * [Usage](#usage)
   * [Connection](#connection)
     * [connect()](#connect)
+    * [query()](#query)
+    * [queryStream()](#querystream)
 * [Install](#install)
 * [Tests](#tests)
 * [License](#license)
@@ -117,6 +119,102 @@ invoking this method without having to await its resolution first.
 
 This method throws an `Exception` if the connection is already initialized,
 i.e. it MUST NOT be called more than once.
+
+#### query()
+
+The `query(string $query, callable|null $callback, mixed ...$params): QueryCommand|null` method can be used to
+perform an async query.
+
+If this SQL statement returns a result set (such as from a `SELECT`
+statement), this method will buffer everything in memory until the result
+set is completed and will then invoke the `$callback` function. This is
+the preferred method if you know your result set to not exceed a few
+dozens or hundreds of rows. If the size of your result set is either
+unknown or known to be too large to fit into memory, you should use the
+[`queryStream()`](#querystream) method instead.
+
+```php
+$connection->query($query, function (QueryCommand $command) {
+    if ($command->hasError()) {
+        // test whether the query was executed successfully
+        // get the error object, instance of Exception.
+        $error = $command->getError();
+        echo 'Error: ' . $error->getMessage() . PHP_EOL;
+    } elseif (isset($command->resultRows)) {
+        // this is a response to a SELECT etc. with some rows (0+)
+        print_r($command->resultFields);
+        print_r($command->resultRows);
+        echo count($command->resultRows) . ' row(s) in set' . PHP_EOL;
+    } else {
+        // this is an OK message in response to an UPDATE etc.
+        if ($command->insertId !== 0) {
+            var_dump('last insert ID', $command->insertId);
+        }
+        echo 'Query OK, ' . $command->affectedRows . ' row(s) affected' . PHP_EOL;
+    }
+});
+```
+
+You can optionally pass any number of `$params` that will be bound to the
+query like this:
+
+```php
+$connection->query('SELECT * FROM user WHERE id > ?', $fn, $id);
+```
+
+The given `$sql` parameter MUST contain a single statement. Support
+for multiple statements is disabled for security reasons because it
+could allow for possible SQL injection attacks and this API is not
+suited for exposing multiple possible results.
+
+#### queryStream()
+
+The `queryStream(string $sql, array $params = array()): ReadableStreamInterface` method can be used to
+perform an async query and stream the rows of the result set.
+
+This method returns a readable stream that will emit each row of the
+result set as a `data` event. It will only buffer data to complete a
+single row in memory and will not store the whole result set. This allows
+you to process result sets of unlimited size that would not otherwise fit
+into memory. If you know your result set to not exceed a few dozens or
+hundreds of rows, you may want to use the [`query()`](#query) method instead.
+
+```php
+$stream = $connection->queryStream('SELECT * FROM user');
+$stream->on('data', function ($row) {
+    echo $row['name'] . PHP_EOL;
+});
+$stream->on('end', function () {
+    echo 'Completed.';
+});
+```
+
+You can optionally pass an array of `$params` that will be bound to the
+query like this:
+
+```php
+$stream = $connection->queryStream('SELECT * FROM user WHERE id > ?', [$id]);
+```
+
+This method is specifically designed for queries that return a result set
+(such as from a `SELECT` or `EXPLAIN` statement). Queries that do not
+return a result set (such as a `UPDATE` or `INSERT` statement) will not
+emit any `data` events.
+
+See also [`ReadableStreamInterface`](https://github.com/reactphp/stream#readablestreaminterface)
+for more details about how readable streams can be used in ReactPHP. For
+example, you can also use its `pipe()` method to forward the result set
+rows to a [`WritableStreamInterface`](https://github.com/reactphp/stream#writablestreaminterface)
+like this:
+
+```php
+$connection->queryStream('SELECT * FROM user')->pipe($formatter)->pipe($logger);
+```
+
+The given `$sql` parameter MUST contain a single statement. Support
+for multiple statements is disabled for security reasons because it
+could allow for possible SQL injection attacks and this API is not
+suited for exposing multiple possible results.
 
 ## Install
 

--- a/examples/02-query-stream.php
+++ b/examples/02-query-stream.php
@@ -1,0 +1,34 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+//create the main loop
+$loop = React\EventLoop\Factory::create();
+
+//create a mysql connection for executing queries
+$connection = new React\MySQL\Connection($loop, array(
+    'dbname' => 'test',
+    'user'   => 'test',
+    'passwd' => 'test',
+));
+
+$connection->connect(function () {});
+
+$sql = isset($argv[1]) ? $argv[1] : 'select * from book';
+
+$stream = $connection->queryStream($sql);
+$stream->on('data', function ($row) {
+    var_dump($row);
+});
+
+$stream->on('error', function (Exception $e) {
+    echo 'Error: ' . $e->getMessage() . PHP_EOL;
+});
+
+$stream->on('close', function () {
+    echo 'CLOSED' . PHP_EOL;
+});
+
+$connection->close();
+
+$loop->run();

--- a/src/Io/Parser.php
+++ b/src/Io/Parser.php
@@ -72,7 +72,6 @@ class Parser extends EventEmitter
 
     protected $rsState = 0;
     protected $pctSize = 0;
-    protected $resultRows = [];
     protected $resultFields = [];
 
     protected $insertId;
@@ -179,7 +178,6 @@ packet:
 
                 $this->rsState = self::RS_STATE_HEADER;
                 $this->resultFields = [];
-                $this->resultRows = [];
                 if ($this->phase === self::PHASE_AUTH_SENT || $this->phase === self::PHASE_GOT_INIT) {
                     $this->phase = self::PHASE_AUTH_ERR;
                 }
@@ -301,7 +299,6 @@ field:
     private function onResultRow($row)
     {
         // $this->debug('row data: ' . json_encode($row));
-        $this->resultRows[] = $row;
         $command = $this->currCommand;
         $command->emit('result', array($row, $command, $command->getConnection()));
     }
@@ -323,13 +320,11 @@ field:
         $command = $this->currCommand;
         $this->currCommand = null;
 
-        $command->resultRows   = $this->resultRows;
         $command->resultFields = $this->resultFields;
-        $command->emit('results', array($this->resultRows, $command, $command->getConnection()));
         $command->emit('end', array($command, $command->getConnection()));
 
         $this->rsState      = self::RS_STATE_HEADER;
-        $this->resultRows   = $this->resultFields = [];
+        $this->resultFields = [];
     }
 
     protected function onSuccess()

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -40,6 +40,14 @@ SQL;
         return $mock;
     }
 
+    protected function expectCallableOnceWith($value)
+    {
+        $mock = $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        $mock->expects($this->once())->method('__invoke')->with($value);
+
+        return $mock;
+    }
+
     protected function expectCallableNever()
     {
         $mock = $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -496,7 +496,7 @@ class ResultQueryTest extends BaseTestCase
 
     public function testEventSelect()
     {
-        $this->expectOutputString('result.result.results.end.');
+        $this->expectOutputString('result.result.end.');
         $loop = \React\EventLoop\Factory::create();
 
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
@@ -509,12 +509,6 @@ class ResultQueryTest extends BaseTestCase
         $connection->query("insert into book (`name`) values ('bar')");
 
         $command = $connection->query('select * from book');
-        $command->on('results', function ($results, $command, $conn) {
-            $this->assertEquals(2, count($results));
-            $this->assertInstanceOf('React\MySQL\Commands\QueryCommand', $command);
-            $this->assertInstanceOf('React\MySQL\Connection', $conn);
-            echo 'results.';
-        });
         $command->on('result', function ($result, $command, $conn) {
                 $this->assertArrayHasKey('id', $result);
                 $this->assertInstanceOf('React\MySQL\Commands\QueryCommand', $command);


### PR DESCRIPTION
This PR adds a new `queryStream()` method which allows processing larger result sets with hundreds or thousands of records, so that one is no longer limited by memory in how many records can be processed. Its API can be used like this:

```php
$stream = $connection->queryStream('SELECT * FROM users');

$stream->on('data', function ($row) {
    var_dump($row);
});
$stream->on('end', function () {
    echo 'DONE' . PHP_EOL;
});
```

Being a new addition to the `ConnectionInterface`, this PR is technically a BC break. This also includes a small patch to ensure that results are no longer buffered internally in the `Parser` and removes its undocumented `results` event. Empirical evidence suggests this should not affect most consumers.

Builds on top of #54
Resolves / closes #50