### PR TITLE
Fix reading all incoming response packets until end

### DIFF
--- a/src/Io/Buffer.php
+++ b/src/Io/Buffer.php
@@ -79,13 +79,17 @@ class Buffer
         $this->bufferPos += $len;
     }
 
-    public function restBuffer($len)
+    /**
+     * Clears all consumed data from the buffer
+     *
+     * This class keeps consumed data in memory for performance reasons and only
+     * advances the internal buffer position until this method is called.
+     *
+     * @return void
+     */
+    public function trim()
     {
-        if ($len !== 0) {
-            $this->skip($len);
-        }
-
-        if (!isset($this->buffer[$this->bufferPos + 1])) {
+        if (!isset($this->buffer[$this->bufferPos])) {
             $this->buffer = '';
         } else {
             $this->buffer = \substr($this->buffer, $this->bufferPos);

--- a/src/Io/Constants.php
+++ b/src/Io/Constants.php
@@ -80,6 +80,11 @@ class Constants
      */
     const CLIENT_MULTI_RESULTS = 131072;
 
+    /**
+     * Client supports plugin authentication (1 << 19)
+     */
+    const CLIENT_PLUGIN_AUTH = 524288;
+
     const FIELD_TYPE_DECIMAL     = 0x00;
     const FIELD_TYPE_TINY        = 0x01;
     const FIELD_TYPE_SHORT       = 0x02;

--- a/tests/Io/BufferTest.php
+++ b/tests/Io/BufferTest.php
@@ -61,6 +61,23 @@ class BufferTest extends \PHPUnit_Framework_TestCase
         $buffer->skip(3);
     }
 
+    public function testTrimEmptyIsNoop()
+    {
+        $buffer = new Buffer();
+        $buffer->trim();
+
+        $this->assertSame(0, $buffer->length());
+    }
+
+    public function testTrimDoesNotChangeLength()
+    {
+        $buffer = new Buffer();
+        $buffer->append('a');
+        $buffer->trim();
+
+        $this->assertSame(1, $buffer->length());
+    }
+
     public function testParseInt1()
     {
         $buffer = new Buffer();


### PR DESCRIPTION
Instead of simply discarding all unknown outstanding data at the end of each packet, we now properly parse the whole packet until its end. If anything would be remaining at the end, this would cause a parsing error for the following packets.

This fixes a subtle bug introduced with https://github.com/friends-of-reactphp/mysql/pull/54/files#diff-2031b03ede17eedd651eae219aa02d8fR88 which caused some outstanding data in long response packets to interfere with the following incoming packets.

This only affects the current master branch and only affects rather long response messages with at least ~16000 entries which is why this wasn't caught by the test suite previously.

Resolves / closes #58 
Builds on top of #54