### PR TITLE
Remove unneeded `listFields()` dummy and `selectDb()` method

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -198,13 +198,6 @@ class Connection extends EventEmitter implements ConnectionInterface
     /**
      * {@inheritdoc}
      */
-    public function listFields()
-    {
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function setOption($name, $value)
     {
         $this->options[$name] = $value;

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -190,14 +190,6 @@ class Connection extends EventEmitter implements ConnectionInterface
     /**
      * {@inheritdoc}
      */
-    public function selectDb($dbname)
-    {
-        return $this->query(sprintf('USE `%s`', $dbname));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function setOption($name, $value)
     {
         $this->options[$name] = $value;

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -152,11 +152,6 @@ interface ConnectionInterface
     public function selectDb($dbname);
 
     /**
-     * @return mixed
-     */
-    public function listFields();
-
-    /**
      * Change connection option parameter.
      *
      * @param string $name  Parameter name.

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -142,16 +142,6 @@ interface ConnectionInterface
     public function ping($callback);
 
     /**
-     * Select specified database.
-     *
-     * @param string $dbname Database name.
-     *
-     * @return QueryCommand
-     * @throws Exception if the connection is not initialized or already closed/closing
-     */
-    public function selectDb($dbname);
-
-    /**
      * Change connection option parameter.
      *
      * @param string $name  Parameter name.


### PR DESCRIPTION
Both methods are not really needed. While the `listFields()` method is only a dummy with no function at all, the `selectDb()` method can simply be replaced by a query like this:

```php
// old
$connection->selectDb('test');

// new (already supported before)
$connection->query('USE test');
```