### PR TITLE
Use QueryResult instead of exposing QueryCommand and mark all commands as internal and move its base to Commands namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $connection = new React\MySQL\Connection($loop, array(
 $connection->connect(function () {});
 
 $connection->query('SELECT * FROM book')->then(
-    function (QueryCommand $command) {
+    function (QueryResult $command) {
         print_r($command->resultFields);
         print_r($command->resultRows);
         echo count($command->resultRows) . ' row(s) in set' . PHP_EOL;
@@ -125,7 +125,7 @@ i.e. it MUST NOT be called more than once.
 The `query(string $query, array $params = array()): PromiseInterface` method can be used to
 perform an async query.
 
-This method returns a promise that will resolve with a `QueryCommand` on
+This method returns a promise that will resolve with a `QueryResult` on
 success or will reject with an `Exception` on error. The MySQL protocol
 is inherently sequential, so that all queries will be performed in order
 and outstanding queries will be put into a queue to be executed once the
@@ -145,7 +145,7 @@ unknown or known to be too large to fit into memory, you should use the
 [`queryStream()`](#querystream) method instead.
 
 ```php
-$connection->query($query)->then(function (QueryCommand $command) {
+$connection->query($query)->then(function (QueryResult $command) {
     if (isset($command->resultRows)) {
         // this is a response to a SELECT etc. with some rows (0+)
         print_r($command->resultFields);

--- a/examples/01-query.php
+++ b/examples/01-query.php
@@ -1,6 +1,6 @@
 <?php
 
-use React\MySQL\Commands\QueryCommand;
+use React\MySQL\QueryResult;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -17,7 +17,7 @@ $connection = new React\MySQL\Connection($loop, array(
 $connection->connect(function () {});
 
 $query = isset($argv[1]) ? $argv[1] : 'select * from book';
-$connection->query($query)->then(function (QueryCommand $command) {
+$connection->query($query)->then(function (QueryResult $command) {
     if (isset($command->resultRows)) {
         // this is a response to a SELECT etc. with some rows (0+)
         print_r($command->resultFields);

--- a/examples/11-interactive.php
+++ b/examples/11-interactive.php
@@ -1,7 +1,7 @@
 <?php
 
-use React\MySQL\Commands\QueryCommand;
 use React\MySQL\ConnectionInterface;
+use React\MySQL\QueryResult;
 use React\Stream\ReadableResourceStream;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -43,7 +43,7 @@ $stdin->on('data', function ($line) use ($connection) {
     }
 
     $time = microtime(true);
-    $connection->query($query)->then(function (QueryCommand $command) use ($time) {
+    $connection->query($query)->then(function (QueryResult $command) use ($time) {
         if (isset($command->resultRows)) {
             // this is a response to a SELECT etc. with some rows (0+)
             echo implode("\t", array_column($command->resultFields, 'name')) . PHP_EOL;

--- a/src/Commands/AbstractCommand.php
+++ b/src/Commands/AbstractCommand.php
@@ -1,10 +1,14 @@
 <?php
 
-namespace React\MySQL;
+namespace React\MySQL\Commands;
 
 use Evenement\EventEmitter;
+use React\MySQL\ConnectionInterface;
 
-abstract class Command extends EventEmitter implements CommandInterface
+/**
+ * @internal
+ */
+abstract class AbstractCommand extends EventEmitter implements CommandInterface
 {
     /**
      * (none, this is an internal thread state)
@@ -137,8 +141,7 @@ abstract class Command extends EventEmitter implements CommandInterface
     /**
      * Construtor.
      *
-     * @param integer $cmd
-     * @param string  $q
+     * @param ConnectionInterface $connection
      */
     public function __construct(ConnectionInterface $connection)
     {

--- a/src/Commands/AuthenticateCommand.php
+++ b/src/Commands/AuthenticateCommand.php
@@ -2,9 +2,10 @@
 
 namespace React\MySQL\Commands;
 
-use React\MySQL\Command;
-
-class AuthenticateCommand extends Command
+/**
+ * @internal
+ */
+class AuthenticateCommand extends AbstractCommand
 {
     public function getId()
     {

--- a/src/Commands/CommandInterface.php
+++ b/src/Commands/CommandInterface.php
@@ -1,9 +1,12 @@
 <?php
 
-namespace React\MySQL;
+namespace React\MySQL\Commands;
 
 use Evenement\EventEmitterInterface;
 
+/**
+ * @internal
+ */
 interface CommandInterface extends EventEmitterInterface
 {
     public function buildPacket();

--- a/src/Commands/PingCommand.php
+++ b/src/Commands/PingCommand.php
@@ -2,9 +2,10 @@
 
 namespace React\MySQL\Commands;
 
-use React\MySQL\Command;
-
-class PingCommand extends Command
+/**
+ * @internal
+ */
+class PingCommand extends AbstractCommand
 {
     public function getId()
     {

--- a/src/Commands/QueryCommand.php
+++ b/src/Commands/QueryCommand.php
@@ -2,10 +2,12 @@
 
 namespace React\MySQL\Commands;
 
-use React\MySQL\Command;
 use React\MySQL\Io\Query;
 
-class QueryCommand extends Command
+/**
+ * @internal
+ */
+class QueryCommand extends AbstractCommand
 {
     public $query;
     public $fields;

--- a/src/Commands/QuitCommand.php
+++ b/src/Commands/QuitCommand.php
@@ -2,9 +2,10 @@
 
 namespace React\MySQL\Commands;
 
-use React\MySQL\Command;
-
-class QuitCommand extends Command
+/**
+ * @internal
+ */
+class QuitCommand extends AbstractCommand
 {
     public function getId()
     {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -4,7 +4,9 @@ namespace React\MySQL;
 
 use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
+use React\MySQL\Commands\AbstractCommand;
 use React\MySQL\Commands\AuthenticateCommand;
+use React\MySQL\Commands\CommandInterface;
 use React\MySQL\Commands\PingCommand;
 use React\MySQL\Commands\QueryCommand;
 use React\MySQL\Commands\QuitCommand;
@@ -327,15 +329,13 @@ class Connection extends EventEmitter implements ConnectionInterface
     }
 
     /**
-     * @param Command $command The command which should be executed.
-     *
+     * @param CommandInterface $command The command which should be executed.
      * @return CommandInterface
-     *
-     * @throws Exception Cann't send command
+     * @throws Exception Can't send command
      */
-    protected function _doCommand(Command $command)
+    protected function _doCommand(CommandInterface $command)
     {
-        if ($command->equals(Command::INIT_AUTHENTICATE)) {
+        if ($command->equals(AbstractCommand::INIT_AUTHENTICATE)) {
             return $this->executor->undequeue($command);
         } elseif ($this->state >= self::STATE_CONNECTING && $this->state <= self::STATE_AUTHENTICATED) {
             return $this->executor->enqueue($command);

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -115,10 +115,12 @@ class Connection extends EventEmitter implements ConnectionInterface
             $rows[] = $row;
         });
         $command->on('end', function ($command) use ($deferred, &$rows) {
-            $command->resultRows = $rows;
+            $result = new QueryResult();
+            $result->resultFields = $command->resultFields;
+            $result->resultRows = $rows;
             $rows = array();
 
-            $deferred->resolve($command);
+            $deferred->resolve($result);
         });
 
         // resolve / reject status reply (response without result set)
@@ -126,7 +128,11 @@ class Connection extends EventEmitter implements ConnectionInterface
             $deferred->reject($error);
         });
         $command->on('success', function (QueryCommand $command) use ($deferred) {
-            $deferred->resolve($command);
+            $result = new QueryResult();
+            $result->affectedRows = $command->affectedRows;
+            $result->insertId = $command->insertId;
+
+            $deferred->resolve($result);
         });
 
         return $deferred->promise();

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -2,8 +2,8 @@
 
 namespace React\MySQL;
 
-use React\Stream\ReadableStreamInterface;
 use React\Promise\PromiseInterface;
+use React\Stream\ReadableStreamInterface;
 
 /**
  * Interface ConnectionInterface
@@ -24,7 +24,7 @@ interface ConnectionInterface
     /**
      * Performs an async query.
      *
-     * This method returns a promise that will resolve with a `QueryCommand` on
+     * This method returns a promise that will resolve with a `QueryResult` on
      * success or will reject with an `Exception` on error. The MySQL protocol
      * is inherently sequential, so that all queries will be performed in order
      * and outstanding queries will be put into a queue to be executed once the
@@ -44,7 +44,7 @@ interface ConnectionInterface
      * [`queryStream()`](#querystream) method instead.
      *
      * ```php
-     * $connection->query($query)->then(function (QueryCommand $command) {
+     * $connection->query($query)->then(function (QueryResult $command) {
      *     if (isset($command->resultRows)) {
      *         // this is a response to a SELECT etc. with some rows (0+)
      *         print_r($command->resultFields);
@@ -77,7 +77,7 @@ interface ConnectionInterface
      *
      * @param string $sql    SQL statement
      * @param array  $params Parameters which should be bound to query
-     * @return PromiseInterface Returns a Promise<QueryCommand,Exception>
+     * @return PromiseInterface Returns a Promise<QueryResult,Exception>
      */
     public function query($sql, array $params = array());
 

--- a/src/Io/Parser.php
+++ b/src/Io/Parser.php
@@ -3,8 +3,8 @@
 namespace React\MySQL\Io;
 
 use Evenement\EventEmitter;
+use React\MySQL\Commands\AbstractCommand;
 use React\MySQL\Exception;
-use React\MySQL\Command;
 use React\Stream\DuplexStreamInterface;
 
 /**
@@ -42,7 +42,7 @@ class Parser extends EventEmitter
      * next command from the `Executor` queue. If no command is outstanding,
      * this will be reset to the `null` state.
      *
-     * @var \React\MySQL\Command|null
+     * @var \React\MySQL\Commands\AbstractCommand|null
      */
     protected $currCommand;
 
@@ -341,7 +341,7 @@ field:
         $command = $this->currCommand;
         $this->currCommand = null;
 
-        if ($command->equals(Command::QUERY)) {
+        if ($command->equals(AbstractCommand::QUERY)) {
             $command->affectedRows = $this->affectedRows;
             $command->insertId     = $this->insertId;
             $command->warnCount    = $this->warnCount;
@@ -365,7 +365,7 @@ field:
             $command = $this->currCommand;
             $this->currCommand = null;
 
-            if ($command->equals(Command::QUIT)) {
+            if ($command->equals(AbstractCommand::QUIT)) {
                 $command->emit('success');
             } else {
                 $command->emit('error', array(
@@ -428,7 +428,7 @@ field:
             $command = $this->executor->dequeue();
             $this->currCommand = $command;
 
-            if ($command->equals(Command::INIT_AUTHENTICATE)) {
+            if ($command->equals(AbstractCommand::INIT_AUTHENTICATE)) {
                 $this->authenticate();
             } else {
                 $this->seq = 0;

--- a/src/QueryResult.php
+++ b/src/QueryResult.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace React\MySQL;
+
+class QueryResult
+{
+    /**
+     * last inserted ID (if any)
+     * @var int|null
+     */
+    public $insertId;
+
+    /**
+     * number of affected rows (for UPDATE, DELETE etc.)
+     *
+     * @var int|null
+     */
+    public $affectedRows;
+
+    /**
+     * result set fields (if any)
+     *
+     * @var array|null
+     */
+    public $resultFields;
+
+    /**
+     * result set rows (if any)
+     *
+     * @var array|null
+     */
+    public $resultRows;
+}

--- a/tests/NoResultQueryTest.php
+++ b/tests/NoResultQueryTest.php
@@ -2,7 +2,7 @@
 
 namespace React\Tests\MySQL;
 
-use React\MySQL\Commands\QueryCommand;
+use React\MySQL\QueryResult;
 
 class NoResultQueryTest extends BaseTestCase
 {
@@ -28,7 +28,7 @@ class NoResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query('update book set created=999 where id=999')->then(function (QueryCommand $command) {
+        $connection->query('update book set created=999 where id=999')->then(function (QueryResult $command) {
             $this->assertEquals(0, $command->affectedRows);
         });
 
@@ -43,7 +43,7 @@ class NoResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query("insert into book (`name`) values ('foo')")->then(function (QueryCommand $command) {
+        $connection->query("insert into book (`name`) values ('foo')")->then(function (QueryResult $command) {
             $this->assertEquals(1, $command->affectedRows);
             $this->assertEquals(1, $command->insertId);
         });
@@ -60,7 +60,7 @@ class NoResultQueryTest extends BaseTestCase
         $connection->connect(function () {});
 
         $connection->query("insert into book (`name`) values ('foo')");
-        $connection->query('update book set created=999 where id=1')->then(function (QueryCommand $command) {
+        $connection->query('update book set created=999 where id=1')->then(function (QueryResult $command) {
             $this->assertEquals(1, $command->affectedRows);
         });
 

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -2,8 +2,8 @@
 
 namespace React\Tests\MySQL;
 
-use React\MySQL\Commands\QueryCommand;
 use React\MySQL\Io\Constants;
+use React\MySQL\QueryResult;
 
 class ResultQueryTest extends BaseTestCase
 {
@@ -14,7 +14,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query('select \'foo\'')->then(function (QueryCommand $command) {
+        $connection->query('select \'foo\'')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertSame('foo', reset($command->resultRows[0]));
@@ -62,7 +62,7 @@ class ResultQueryTest extends BaseTestCase
 
         $expected = $value;
 
-        $connection->query('select ?', [$value])->then(function (QueryCommand $command) use ($expected) {
+        $connection->query('select ?', [$value])->then(function (QueryResult $command) use ($expected) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertSame($expected, reset($command->resultRows[0]));
@@ -82,7 +82,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query('select ?', [$value])->then(function (QueryCommand $command) use ($expected) {
+        $connection->query('select ?', [$value])->then(function (QueryResult $command) use ($expected) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertSame($expected, reset($command->resultRows[0]));
@@ -99,7 +99,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query('select \'hello?\'')->then(function (QueryCommand $command) {
+        $connection->query('select \'hello?\'')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertEquals('hello?', reset($command->resultRows[0]));
@@ -119,7 +119,7 @@ class ResultQueryTest extends BaseTestCase
         $length = 40000;
         $value = str_repeat('.', $length);
 
-        $connection->query('SELECT ?', [$value])->then(function (QueryCommand $command) use ($length) {
+        $connection->query('SELECT ?', [$value])->then(function (QueryResult $command) use ($length) {
             $this->assertCount(1, $command->resultFields);
             $this->assertEquals($length * 3, $command->resultFields[0]['length']);
             $this->assertSame(Constants::FIELD_TYPE_VAR_STRING, $command->resultFields[0]['type']);
@@ -136,7 +136,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query('select \'foo\' as ``')->then(function (QueryCommand $command) {
+        $connection->query('select \'foo\' as ``')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertSame('foo', reset($command->resultRows[0]));
@@ -157,7 +157,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query('select null')->then(function (QueryCommand $command) {
+        $connection->query('select null')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertNull(reset($command->resultRows[0]));
@@ -177,7 +177,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query('select "foo" UNION select "bar"')->then(function (QueryCommand $command) {
+        $connection->query('select "foo" UNION select "bar"')->then(function (QueryResult $command) {
             $this->assertCount(2, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -196,7 +196,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query('select "foo" UNION select null')->then(function (QueryCommand $command) {
+        $connection->query('select "foo" UNION select null')->then(function (QueryResult $command) {
             $this->assertCount(2, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -218,7 +218,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query('select 0 UNION select null')->then(function (QueryCommand $command) {
+        $connection->query('select 0 UNION select null')->then(function (QueryResult $command) {
             $this->assertCount(2, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -240,7 +240,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query('select "foo" UNION select 1')->then(function (QueryCommand $command) {
+        $connection->query('select "foo" UNION select 1')->then(function (QueryResult $command) {
             $this->assertCount(2, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -262,7 +262,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query('select "foo" UNION select ""')->then(function (QueryCommand $command) {
+        $connection->query('select "foo" UNION select ""')->then(function (QueryResult $command) {
             $this->assertCount(2, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -281,7 +281,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query('select "foo" LIMIT 0')->then(function (QueryCommand $command) {
+        $connection->query('select "foo" LIMIT 0')->then(function (QueryResult $command) {
             $this->assertCount(0, $command->resultRows);
 
             $this->assertCount(1, $command->resultFields);
@@ -299,7 +299,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query('select "foo","bar"')->then(function (QueryCommand $command) {
+        $connection->query('select "foo","bar"')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(2, $command->resultRows[0]);
 
@@ -318,7 +318,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query('select "foo",""')->then(function (QueryCommand $command) {
+        $connection->query('select "foo",""')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(2, $command->resultRows[0]);
 
@@ -337,7 +337,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query('select \'\' as `first`, \'\' as `second`')->then(function (QueryCommand $command) {
+        $connection->query('select \'\' as `first`, \'\' as `second`')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(2, $command->resultRows[0]);
             $this->assertSame(array('', ''), array_values($command->resultRows[0]));
@@ -358,7 +358,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
         $connection->connect(function () {});
 
-        $connection->query('select "foo" as `col`,"bar" as `col`')->then(function (QueryCommand $command) {
+        $connection->query('select "foo" as `col`,"bar" as `col`')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -386,7 +386,7 @@ class ResultQueryTest extends BaseTestCase
         $connection->query("insert into book (`name`) values ('foo')");
         $connection->query("insert into book (`name`) values ('bar')");
 
-        $connection->query('select * from book')->then(function (QueryCommand $command) {
+        $connection->query('select * from book')->then(function (QueryResult $command) {
             $this->assertCount(2, $command->resultRows);
         });
 
@@ -451,12 +451,12 @@ class ResultQueryTest extends BaseTestCase
         $command = $connection->query('select * from book');
         $command->on('result', function ($result, $command, $conn) {
                 $this->assertArrayHasKey('id', $result);
-                $this->assertInstanceOf('React\MySQL\Commands\QueryCommand', $command);
+                $this->assertInstanceOf('React\MySQL\Commands\QueryResult', $command);
                 $this->assertInstanceOf('React\MySQL\Connection', $conn);
                 echo 'result.';
             })
             ->on('end', function ($command, $conn) {
-                $this->assertInstanceOf('React\MySQL\Commands\QueryCommand', $command);
+                $this->assertInstanceOf('React\MySQL\Commands\QueryResult', $command);
                 $this->assertInstanceOf('React\MySQL\Connection', $conn);
                 echo 'end.';
             });
@@ -472,7 +472,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = new \React\MySQL\Connection($loop, $this->getConnectionOptions());
 
         $callback = function () use ($connection) {
-            $connection->query('select 1+1')->then(function (QueryCommand $command) {
+            $connection->query('select 1+1')->then(function (QueryResult $command) {
                 $this->assertEquals([['1+1' => 2]], $command->resultRows);
             });
             $connection->close();


### PR DESCRIPTION
Similar to #53, the whole `Command` class hierarchy is now marked as internal and will receive a number of patches to clean up its interfaces. The `query()` method now resolves with a `QueryResult` instead of a `QueryCommand`. Its public properties have been left unchanged, so migrating existing code should not be too hard.

Builds on top of #61 and #53 