### PR TITLE
Use promises for ping() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It is written in pure PHP and does not require any extensions.
     * [connect()](#connect)
     * [query()](#query)
     * [queryStream()](#querystream)
+    * [ping()](#ping)
 * [Install](#install)
 * [Tests](#tests)
 * [License](#license)
@@ -224,6 +225,25 @@ The given `$sql` parameter MUST contain a single statement. Support
 for multiple statements is disabled for security reasons because it
 could allow for possible SQL injection attacks and this API is not
 suited for exposing multiple possible results.
+
+#### ping()
+
+The `ping(): PromiseInterface<true, Exception>` method can be used to
+check that the connection is alive.
+
+This method returns a promise that will resolve with a boolean `true` on
+success or will reject with an `Exception` on error. The MySQL protocol
+is inherently sequential, so that all commands will be performed in order
+and outstanding command will be put into a queue to be executed once the
+previous queries are completed.
+
+```php
+$connection->ping()->then(function () {
+    echo 'OK' . PHP_EOL;
+}, function (Exception $e) {
+    echo 'Error: ' . $e->getMessage() . PHP_EOL;
+});
+```
 
 ## Install
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -14,6 +14,7 @@ use React\MySQL\Io\Executor;
 use React\MySQL\Io\Parser;
 use React\MySQL\Io\Query;
 use React\Promise\Deferred;
+use React\Promise\Promise;
 use React\Socket\ConnectionInterface as SocketConnectionInterface;
 use React\Socket\Connector;
 use React\Socket\ConnectorInterface;
@@ -173,21 +174,17 @@ class Connection extends EventEmitter implements ConnectionInterface
         return $stream;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function ping($callback)
+    public function ping()
     {
-        if (!is_callable($callback)) {
-            throw new \InvalidArgumentException('Callback is not a valid callable');
-        }
-        $this->_doCommand(new PingCommand($this))
-            ->on('error', function ($reason) use ($callback) {
-                $callback($reason, $this);
-            })
-            ->on('success', function () use ($callback) {
-                $callback(null, $this);
-            });
+        return new Promise(function ($resolve, $reject) {
+            $this->_doCommand(new PingCommand($this))
+                ->on('error', function ($reason) use ($reject) {
+                    $reject($reason);
+                })
+                ->on('success', function () use ($resolve) {
+                    $resolve(true);
+                });
+        });
     }
 
     /**

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -135,18 +135,25 @@ interface ConnectionInterface
     public function queryStream($sql, $params = array());
 
     /**
-     * Checks that connection is alive.
+     * Checks that the connection is alive.
      *
-     * @param callable $callback Checking result handler.
+     * This method returns a promise that will resolve with a boolean `true` on
+     * success or will reject with an `Exception` on error. The MySQL protocol
+     * is inherently sequential, so that all commands will be performed in order
+     * and outstanding command will be put into a queue to be executed once the
+     * previous queries are completed.
      *
-     * $callback signature:
+     * ```php
+     * $connection->ping()->then(function () {
+     *     echo 'OK' . PHP_EOL;
+     * }, function (Exception $e) {
+     *     echo 'Error: ' . $e->getMessage() . PHP_EOL;
+     * });
+     * ```
      *
-     *  function (\Exception $e = null, ConnectionInterface $conn): void
-     *
-     * @return void
-     * @throws Exception if the connection is not initialized or already closed/closing
+     * @return PromiseInterface Returns a Promise<true,Exception>
      */
-    public function ping($callback);
+    public function ping();
 
     /**
      * Change connection option parameter.


### PR DESCRIPTION
This PR updates the `ping()` method to use promises instead of accepting a required callback function.

```php
// old
$connection->ping(function ($error, $connection) {
    if ($error) {
        echo 'Error: ' . $error->getMessage() . PHP_EOL;
    } else {
        echo 'OK' . PHP_EOL;
    }
});

// new 
$connection->ping(function () {
    echo 'OK' . PHP_EOL;
}, function (Exception $error) {
    echo 'Error: ' . $error->getMessage() . PHP_EOL;
});
```

This PR also includes relevant documentation and tests. The old method definition was somewhat inconsistent and under-documented.

Builds on top of #61 
Refs #4