### PR TITLE
Rename close() to quit() and use promises for quit() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,10 +261,10 @@ $connection->ping()->then(function () {
 
 #### quit()
 
-The `quit(): PromiseInterface<true, Exception>` method can be used to
+The `quit(): PromiseInterface<void, Exception>` method can be used to
 quit (soft-close) the connection.
 
-This method returns a promise that will resolve with a boolean `true` on
+This method returns a promise that will resolve (with a void value) on
 success or will reject with an `Exception` on error. The MySQL protocol
 is inherently sequential, so that all commands will be performed in order
 and outstanding commands will be put into a queue to be executed once the

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $factory->createConnection($uri)->then(function (ConnectionInterface $connection
         }
     );
     
-    $connection->close();
+    $connection->quit();
 });
 
 $loop->run();
@@ -257,6 +257,22 @@ $connection->ping()->then(function () {
 }, function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });
+```
+
+#### quit()
+
+The `quit(): PromiseInterface<true, Exception>` method can be used to
+quit (soft-close) the connection.
+
+This method returns a promise that will resolve with a boolean `true` on
+success or will reject with an `Exception` on error. The MySQL protocol
+is inherently sequential, so that all commands will be performed in order
+and outstanding commands will be put into a queue to be executed once the
+previous commands are completed.
+
+```php
+$connection->query('CREATE TABLE test ...');
+$connection->quit();
 ```
 
 ## Install

--- a/examples/01-query.php
+++ b/examples/01-query.php
@@ -32,7 +32,7 @@ $factory->createConnection($uri)->then(function (ConnectionInterface $connection
         echo 'Error: ' . $error->getMessage() . PHP_EOL;
     });
 
-    $connection->close();
+    $connection->quit();
 }, 'printf');
 
 $loop->run();

--- a/examples/02-query-stream.php
+++ b/examples/02-query-stream.php
@@ -26,7 +26,7 @@ $factory->createConnection($uri)->then(function (ConnectionInterface $connection
         echo 'CLOSED' . PHP_EOL;
     });
 
-    $connection->close();
+    $connection->quit();
 }, 'printf');
 
 $loop->run();

--- a/examples/11-interactive.php
+++ b/examples/11-interactive.php
@@ -31,7 +31,7 @@ $factory->createConnection($uri)->then(function (ConnectionInterface $connection
         if ($query === 'exit') {
             // exit command should close the connection
             echo 'bye.' . PHP_EOL;
-            $connection->close();
+            $connection->quit();
             return;
         }
 
@@ -74,9 +74,7 @@ $factory->createConnection($uri)->then(function (ConnectionInterface $connection
 
     // close connection when STDIN closes (EOF or CTRL+D)
     $stdin->on('close', function () use ($connection) {
-        if ($connection->getState() === ConnectionInterface::STATE_AUTHENTICATED) {
-            $connection->close();
-        }
+        $connection->quit();
     });
 
     // close STDIN (stop reading) when connection closes

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -208,17 +208,20 @@ interface ConnectionInterface
     public function getState();
 
     /**
-     * Close the connection.
+     * Quits (soft-close) the connection.
      *
-     * @param callable|null $callback A callback which should be run after
-     *                                connection successfully closed.
+     * This method returns a promise that will resolve with a boolean `true` on
+     * success or will reject with an `Exception` on error. The MySQL protocol
+     * is inherently sequential, so that all commands will be performed in order
+     * and outstanding commands will be put into a queue to be executed once the
+     * previous commands are completed.
      *
-     * $callback signature:
+     * ```php
+     * $connection->query('CREATE TABLE test ...');
+     * $connection->quit();
+     * ```
      *
-     *  function (ConnectionInterface $conn): void
-     *
-     * @return void
-     * @throws Exception if the connection is not initialized or already closed/closing
+     * @return PromiseInterface Returns a Promise<true,Exception>
      */
-    public function close($callback = null);
+    public function quit();
 }

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -210,7 +210,7 @@ interface ConnectionInterface
     /**
      * Quits (soft-close) the connection.
      *
-     * This method returns a promise that will resolve with a boolean `true` on
+     * This method returns a promise that will resolve (with a void value) on
      * success or will reject with an `Exception` on error. The MySQL protocol
      * is inherently sequential, so that all commands will be performed in order
      * and outstanding commands will be put into a queue to be executed once the
@@ -221,7 +221,7 @@ interface ConnectionInterface
      * $connection->quit();
      * ```
      *
-     * @return PromiseInterface Returns a Promise<true,Exception>
+     * @return PromiseInterface Returns a Promise<void,Exception>
      */
     public function quit();
 }

--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -226,7 +226,7 @@ class Connection extends EventEmitter implements ConnectionInterface
                     $this->state = self::STATE_CLOSED;
                     $this->emit('end', [$this]);
                     $this->emit('close', [$this]);
-                    $resolve(true);
+                    $resolve();
                 });
             $this->state = self::STATE_CLOSEING;
         });

--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -215,21 +215,21 @@ class Connection extends EventEmitter implements ConnectionInterface
         return $this->state;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function close($callback = null)
+    public function quit()
     {
-        $this->_doCommand(new QuitCommand($this))
-            ->on('success', function () use ($callback) {
-                $this->state = self::STATE_CLOSED;
-                $this->emit('end', [$this]);
-                $this->emit('close', [$this]);
-                if (is_callable($callback)) {
-                    $callback($this);
-                }
-            });
-        $this->state = self::STATE_CLOSEING;
+        return new Promise(function ($resolve, $reject) {
+            $this->_doCommand(new QuitCommand($this))
+                ->on('error', function ($reason) use ($reject) {
+                    $reject($reason);
+                })
+                ->on('success', function () use ($resolve) {
+                    $this->state = self::STATE_CLOSED;
+                    $this->emit('end', [$this]);
+                    $this->emit('close', [$this]);
+                    $resolve(true);
+                });
+            $this->state = self::STATE_CLOSEING;
+        });
     }
 
     /**

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -106,7 +106,7 @@ class FactoryTest extends BaseTestCase
         $uri = $this->getConnectionString();
         $factory->createConnection($uri)->then(function (ConnectionInterface $connection) {
             echo 'connected.';
-            $connection->close(function ($e) {
+            $connection->quit()->then(function () {
                 echo 'closed.';
             });
         }, 'printf')->then(null, 'printf');
@@ -127,7 +127,7 @@ class FactoryTest extends BaseTestCase
             $connection->ping()->then(function () {
                 echo 'ping.';
             });
-            $connection->close(function ($e) {
+            $connection->quit()->then(function () {
                 echo 'closed.';
             });
         }, 'printf')->then(null, 'printf');

--- a/tests/NoResultQueryTest.php
+++ b/tests/NoResultQueryTest.php
@@ -15,7 +15,7 @@ class NoResultQueryTest extends BaseTestCase
         $connection->query('DROP TABLE IF EXISTS book');
         $connection->query($this->getDataTable());
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -28,7 +28,7 @@ class NoResultQueryTest extends BaseTestCase
             $this->assertEquals(0, $command->affectedRows);
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -42,7 +42,7 @@ class NoResultQueryTest extends BaseTestCase
             $this->assertEquals(1, $command->insertId);
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -56,7 +56,7 @@ class NoResultQueryTest extends BaseTestCase
             $this->assertEquals(1, $command->affectedRows);
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 }

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -20,7 +20,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertInstanceOf('React\MySQL\Connection', $conn);
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -64,7 +64,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertSame($expected, reset($command->resultRows[0]));
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -82,7 +82,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertSame($expected, reset($command->resultRows[0]));
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -97,7 +97,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertEquals('hello?', reset($command->resultRows[0]));
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -115,7 +115,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertSame(Constants::FIELD_TYPE_VAR_STRING, $command->resultFields[0]['type']);
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -134,7 +134,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertSame('', $command->resultFields[0]['name']);
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -152,7 +152,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertSame(Constants::FIELD_TYPE_NULL, $command->resultFields[0]['type']);
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -169,7 +169,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertSame('bar', reset($command->resultRows[1]));
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -189,7 +189,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertSame(Constants::FIELD_TYPE_VAR_STRING, $command->resultFields[0]['type']);
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -209,7 +209,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertSame(Constants::FIELD_TYPE_LONGLONG, $command->resultFields[0]['type']);
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -229,7 +229,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertSame(Constants::FIELD_TYPE_VAR_STRING, $command->resultFields[0]['type']);
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -246,7 +246,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertSame('', reset($command->resultRows[1]));
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -262,7 +262,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertSame('foo', $command->resultFields[0]['name']);
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -279,7 +279,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertSame('bar', next($command->resultRows[0]));
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -296,7 +296,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertSame('', next($command->resultRows[0]));
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -315,7 +315,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertSame(Constants::FIELD_TYPE_VAR_STRING, $command->resultFields[1]['type']);
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -335,7 +335,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertSame('col', $command->resultFields[1]['name']);
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -354,7 +354,7 @@ class ResultQueryTest extends BaseTestCase
             $this->assertCount(2, $command->resultRows);
         });
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -373,7 +373,7 @@ class ResultQueryTest extends BaseTestCase
             }
         );
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -389,7 +389,7 @@ class ResultQueryTest extends BaseTestCase
             }
         );
 
-        $connection->close();
+        $connection->quit();
         $loop->run();
     }
 
@@ -402,7 +402,7 @@ class ResultQueryTest extends BaseTestCase
             $connection->query('select 1+1')->then(function (QueryResult $command) {
                 $this->assertEquals([['1+1' => 2]], $command->resultRows);
             });
-            $connection->close();
+            $connection->quit();
         });
 
         $timeout = $loop->addTimer(1, function () use ($loop) {
@@ -426,7 +426,7 @@ class ResultQueryTest extends BaseTestCase
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('close', $this->expectCallableOnce());
 
-        $connection->close();
+        $connection->quit();
 
         $loop->run();
     }
@@ -441,7 +441,7 @@ class ResultQueryTest extends BaseTestCase
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('close', $this->expectCallableOnce());
 
-        $connection->close();
+        $connection->quit();
 
         $loop->run();
     }
@@ -456,7 +456,7 @@ class ResultQueryTest extends BaseTestCase
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('close', $this->expectCallableOnce());
 
-        $connection->close();
+        $connection->quit();
 
         $loop->run();
     }
@@ -472,7 +472,7 @@ class ResultQueryTest extends BaseTestCase
         $stream->on('error', $this->expectCallableOnce());
         $stream->on('close', $this->expectCallableOnce());
 
-        $connection->close();
+        $connection->quit();
 
         $loop->run();
     }
@@ -487,7 +487,7 @@ class ResultQueryTest extends BaseTestCase
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('close', $this->expectCallableOnce());
 
-        $connection->close();
+        $connection->quit();
 
         $loop->run();
     }


### PR DESCRIPTION
This PR renames the existing `close()` method to `quit()` and uses promises for this method instead.

```php
// old
$connection->close(function () {
    echo 'closed';
});

// new
$connection->quit()->then(function () {
    echo 'closed';
});
```

This PR also includes relevant documentation and tests. The old `close()` method definition was somewhat inconsistent and under-documented.

Builds on top of #64
Refs #4 