### PR TITLE
Update ping() to resolve with void value on success

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,10 +242,10 @@ suited for exposing multiple possible results.
 
 #### ping()
 
-The `ping(): PromiseInterface<true, Exception>` method can be used to
+The `ping(): PromiseInterface<void, Exception>` method can be used to
 check that the connection is alive.
 
-This method returns a promise that will resolve with a boolean `true` on
+This method returns a promise that will resolve (with a void value) on
 success or will reject with an `Exception` on error. The MySQL protocol
 is inherently sequential, so that all commands will be performed in order
 and outstanding command will be put into a queue to be executed once the

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -137,7 +137,7 @@ interface ConnectionInterface
     /**
      * Checks that the connection is alive.
      *
-     * This method returns a promise that will resolve with a boolean `true` on
+     * This method returns a promise that will resolve (with a void value) on
      * success or will reject with an `Exception` on error. The MySQL protocol
      * is inherently sequential, so that all commands will be performed in order
      * and outstanding command will be put into a queue to be executed once the

--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -180,7 +180,7 @@ class Connection extends EventEmitter implements ConnectionInterface
                     $reject($reason);
                 })
                 ->on('success', function () use ($resolve) {
-                    $resolve(true);
+                    $resolve();
                 });
         });
     }


### PR DESCRIPTION
This simple PR updates the `ping()` method to resolve with a void value on success instead of a (rather pointless) boolean true value (recently introduced via #63). This means that this is now in line with the new `quit()` method (just introduced via #65).

Builds on top of #63 and #65 