### PR TITLE
Internal refactoring to remove unneeded references from Commands

### DIFF
--- a/src/Commands/AbstractCommand.php
+++ b/src/Commands/AbstractCommand.php
@@ -3,7 +3,6 @@
 namespace React\MySQL\Commands;
 
 use Evenement\EventEmitter;
-use React\MySQL\ConnectionInterface;
 
 /**
  * @internal
@@ -132,21 +131,9 @@ abstract class AbstractCommand extends EventEmitter implements CommandInterface
      */
     const INIT_AUTHENTICATE = 0xf1;
 
-    protected $connection;
-
     private $states = [];
 
     private $error;
-
-    /**
-     * Construtor.
-     *
-     * @param ConnectionInterface $connection
-     */
-    public function __construct(ConnectionInterface $connection)
-    {
-        $this->connection = $connection;
-    }
 
     public function getState($name, $default = null)
     {
@@ -182,10 +169,5 @@ abstract class AbstractCommand extends EventEmitter implements CommandInterface
     public function hasError()
     {
         return (boolean) $this->error;
-    }
-
-    public function getConnection()
-    {
-        return $this->connection;
     }
 }

--- a/src/Commands/AbstractCommand.php
+++ b/src/Commands/AbstractCommand.php
@@ -130,9 +130,4 @@ abstract class AbstractCommand extends EventEmitter implements CommandInterface
      * Authenticate after the connection is established, only for this project.
      */
     const INIT_AUTHENTICATE = 0xf1;
-
-    public function equals($commandId)
-    {
-        return $this->getId() === $commandId;
-    }
 }

--- a/src/Commands/AbstractCommand.php
+++ b/src/Commands/AbstractCommand.php
@@ -131,24 +131,6 @@ abstract class AbstractCommand extends EventEmitter implements CommandInterface
      */
     const INIT_AUTHENTICATE = 0xf1;
 
-    private $states = [];
-
-    public function getState($name, $default = null)
-    {
-        if (isset($this->states[$name])) {
-            return $this->states[$name];
-        }
-
-        return $default;
-    }
-
-    public function setState($name, $value)
-    {
-        $this->states[$name] = $value;
-
-        return $this;
-    }
-
     public function equals($commandId)
     {
         return $this->getId() === $commandId;

--- a/src/Commands/AbstractCommand.php
+++ b/src/Commands/AbstractCommand.php
@@ -133,8 +133,6 @@ abstract class AbstractCommand extends EventEmitter implements CommandInterface
 
     private $states = [];
 
-    private $error;
-
     public function getState($name, $default = null)
     {
         if (isset($this->states[$name])) {
@@ -154,20 +152,5 @@ abstract class AbstractCommand extends EventEmitter implements CommandInterface
     public function equals($commandId)
     {
         return $this->getId() === $commandId;
-    }
-
-    public function setError(\Exception $error)
-    {
-        $this->error = $error;
-    }
-
-    public function getError()
-    {
-        return $this->error;
-    }
-
-    public function hasError()
-    {
-        return (boolean) $this->error;
     }
 }

--- a/src/Commands/CommandInterface.php
+++ b/src/Commands/CommandInterface.php
@@ -11,5 +11,4 @@ interface CommandInterface extends EventEmitterInterface
 {
     public function buildPacket();
     public function getId();
-    public function equals($commandId);
 }

--- a/src/Commands/CommandInterface.php
+++ b/src/Commands/CommandInterface.php
@@ -11,7 +11,5 @@ interface CommandInterface extends EventEmitterInterface
 {
     public function buildPacket();
     public function getId();
-    public function setState($name, $value);
-    public function getState($name, $default = null);
     public function equals($commandId);
 }

--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -100,7 +100,7 @@ class Connection extends EventEmitter implements ConnectionInterface
             $query->bindParamsFromArray($params);
         }
 
-        $command = new QueryCommand($this);
+        $command = new QueryCommand();
         $command->setQuery($query);
         try {
             $this->_doCommand($command);
@@ -146,7 +146,7 @@ class Connection extends EventEmitter implements ConnectionInterface
             $query->bindParamsFromArray($params);
         }
 
-        $command = new QueryCommand($this);
+        $command = new QueryCommand();
         $command->setQuery($query);
         $this->_doCommand($command);
 
@@ -175,7 +175,7 @@ class Connection extends EventEmitter implements ConnectionInterface
     public function ping()
     {
         return new Promise(function ($resolve, $reject) {
-            $this->_doCommand(new PingCommand($this))
+            $this->_doCommand(new PingCommand())
                 ->on('error', function ($reason) use ($reject) {
                     $reject($reason);
                 })
@@ -218,7 +218,7 @@ class Connection extends EventEmitter implements ConnectionInterface
     public function quit()
     {
         return new Promise(function ($resolve, $reject) {
-            $this->_doCommand(new QuitCommand($this))
+            $this->_doCommand(new QuitCommand())
                 ->on('error', function ($reason) use ($reject) {
                     $reject($reason);
                 })
@@ -272,7 +272,7 @@ class Connection extends EventEmitter implements ConnectionInterface
 
                 $parser->setOptions($options);
 
-                $command = $this->_doCommand(new AuthenticateCommand($this));
+                $command = $this->_doCommand(new AuthenticateCommand());
                 $command->on('authenticated', $connectedHandler);
                 $command->on('error', $errorHandler);
 

--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -4,7 +4,6 @@ namespace React\MySQL\Io;
 
 use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
-use React\MySQL\Commands\AbstractCommand;
 use React\MySQL\Commands\AuthenticateCommand;
 use React\MySQL\Commands\CommandInterface;
 use React\MySQL\Commands\PingCommand;
@@ -335,7 +334,7 @@ class Connection extends EventEmitter implements ConnectionInterface
      */
     protected function _doCommand(CommandInterface $command)
     {
-        if ($command->equals(AbstractCommand::INIT_AUTHENTICATE)) {
+        if ($command instanceof AuthenticateCommand) {
             return $this->executor->undequeue($command);
         } elseif ($this->state >= self::STATE_CONNECTING && $this->state <= self::STATE_AUTHENTICATED) {
             return $this->executor->enqueue($command);

--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -114,7 +114,7 @@ class Connection extends EventEmitter implements ConnectionInterface
         $command->on('result', function ($row) use (&$rows) {
             $rows[] = $row;
         });
-        $command->on('end', function ($command) use ($deferred, &$rows) {
+        $command->on('end', function () use ($command, $deferred, &$rows) {
             $result = new QueryResult();
             $result->resultFields = $command->resultFields;
             $result->resultRows = $rows;
@@ -127,7 +127,7 @@ class Connection extends EventEmitter implements ConnectionInterface
         $command->on('error', function ($error) use ($deferred) {
             $deferred->reject($error);
         });
-        $command->on('success', function (QueryCommand $command) use ($deferred) {
+        $command->on('success', function () use ($command, $deferred) {
             $result = new QueryResult();
             $result->affectedRows = $command->affectedRows;
             $result->insertId = $command->insertId;
@@ -320,9 +320,7 @@ class Connection extends EventEmitter implements ConnectionInterface
         while (!$this->executor->isIdle()) {
             $command = $this->executor->dequeue();
             $command->emit('error', array(
-                new \RuntimeException('Connection lost'),
-                $command,
-                $this
+                new \RuntimeException('Connection lost')
             ));
         }
     }

--- a/src/Io/Parser.php
+++ b/src/Io/Parser.php
@@ -3,7 +3,9 @@
 namespace React\MySQL\Io;
 
 use Evenement\EventEmitter;
-use React\MySQL\Commands\AbstractCommand;
+use React\MySQL\Commands\AuthenticateCommand;
+use React\MySQL\Commands\QueryCommand;
+use React\MySQL\Commands\QuitCommand;
 use React\MySQL\Exception;
 use React\Stream\DuplexStreamInterface;
 
@@ -340,7 +342,7 @@ field:
         $command = $this->currCommand;
         $this->currCommand = null;
 
-        if ($command->equals(AbstractCommand::QUERY)) {
+        if ($command instanceof QueryCommand) {
             $command->affectedRows = $this->affectedRows;
             $command->insertId     = $this->insertId;
             $command->warnCount    = $this->warnCount;
@@ -364,7 +366,7 @@ field:
             $command = $this->currCommand;
             $this->currCommand = null;
 
-            if ($command->equals(AbstractCommand::QUIT)) {
+            if ($command instanceof QuitCommand) {
                 $command->emit('success');
             } else {
                 $command->emit('error', array(
@@ -426,7 +428,7 @@ field:
             $command = $this->executor->dequeue();
             $this->currCommand = $command;
 
-            if ($command->equals(AbstractCommand::INIT_AUTHENTICATE)) {
+            if ($command instanceof AuthenticateCommand) {
                 $this->authenticate();
             } else {
                 $this->seq = 0;

--- a/src/Io/Parser.php
+++ b/src/Io/Parser.php
@@ -311,7 +311,7 @@ field:
     {
         // $this->debug('row data: ' . json_encode($row));
         $command = $this->currCommand;
-        $command->emit('result', array($row, $command));
+        $command->emit('result', array($row));
     }
 
     protected function onError()
@@ -320,9 +320,9 @@ field:
         $this->currCommand = null;
 
         $error = new Exception($this->errmsg, $this->errno);
-        $command->emit('error', array($error, $command));
         $this->errmsg = '';
         $this->errno  = 0;
+        $command->emit('error', array($error));
     }
 
     protected function onResultDone()
@@ -331,7 +331,7 @@ field:
         $this->currCommand = null;
 
         $command->resultFields = $this->resultFields;
-        $command->emit('end', array($command));
+        $command->emit('end');
 
         $this->rsState      = self::RS_STATE_HEADER;
         $this->resultFields = [];
@@ -348,7 +348,7 @@ field:
             $command->warnCount    = $this->warnCount;
             $command->message      = $this->message;
         }
-        $command->emit('success', array($command));
+        $command->emit('success');
     }
 
     protected function onAuthenticated()
@@ -370,8 +370,7 @@ field:
                 $command->emit('success');
             } else {
                 $command->emit('error', array(
-                    new \RuntimeException('Connection lost'),
-                    $command
+                    new \RuntimeException('Connection lost')
                 ));
             }
         }

--- a/src/Io/Parser.php
+++ b/src/Io/Parser.php
@@ -318,7 +318,6 @@ field:
         $this->currCommand = null;
 
         $error = new Exception($this->errmsg, $this->errno);
-        $command->setError($error);
         $command->emit('error', array($error, $command));
         $this->errmsg = '';
         $this->errno  = 0;

--- a/src/Io/Parser.php
+++ b/src/Io/Parser.php
@@ -309,7 +309,7 @@ field:
     {
         // $this->debug('row data: ' . json_encode($row));
         $command = $this->currCommand;
-        $command->emit('result', array($row, $command, $command->getConnection()));
+        $command->emit('result', array($row, $command));
     }
 
     protected function onError()
@@ -319,7 +319,7 @@ field:
 
         $error = new Exception($this->errmsg, $this->errno);
         $command->setError($error);
-        $command->emit('error', array($error, $command, $command->getConnection()));
+        $command->emit('error', array($error, $command));
         $this->errmsg = '';
         $this->errno  = 0;
     }
@@ -330,7 +330,7 @@ field:
         $this->currCommand = null;
 
         $command->resultFields = $this->resultFields;
-        $command->emit('end', array($command, $command->getConnection()));
+        $command->emit('end', array($command));
 
         $this->rsState      = self::RS_STATE_HEADER;
         $this->resultFields = [];
@@ -347,7 +347,7 @@ field:
             $command->warnCount    = $this->warnCount;
             $command->message      = $this->message;
         }
-        $command->emit('success', array($command, $command->getConnection()));
+        $command->emit('success', array($command));
     }
 
     protected function onAuthenticated()
@@ -370,8 +370,7 @@ field:
             } else {
                 $command->emit('error', array(
                     new \RuntimeException('Connection lost'),
-                    $command,
-                    $command->getConnection()
+                    $command
                 ));
             }
         }


### PR DESCRIPTION
This simple PR removes a number of unneeded references from the internal Commands. This did not affect outside behavior and is not a BC break.

Builds on top of #62