### PR TITLE
Remove unneeded ConnectionInterface methods getState(), getOptions(), setOptions() and getServerOptions()

### DIFF
--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -12,15 +12,6 @@ use React\Stream\ReadableStreamInterface;
  */
 interface ConnectionInterface
 {
-    const STATE_INIT                = 0;
-    const STATE_CONNECT_FAILED      = 1;
-    const STATE_AUTHENTICATE_FAILED = 2;
-    const STATE_CONNECTING          = 3;
-    const STATE_CONNECTED           = 4;
-    const STATE_AUTHENTICATED       = 5;
-    const STATE_CLOSEING            = 6;
-    const STATE_CLOSED              = 7;
-
     /**
      * Performs an async query.
      *
@@ -190,22 +181,6 @@ interface ConnectionInterface
      * @return array
      */
     public function getServerOptions();
-
-    /**
-     * Get connection state.
-     *
-     * @return integer
-     *
-     * @see ConnectionInterface::STATE_INIT
-     * @see ConnectionInterface::STATE_CONNECT_FAILED
-     * @see ConnectionInterface::STATE_AUTHENTICATE_FAILED
-     * @see ConnectionInterface::STATE_CONNECTING
-     * @see ConnectionInterface::STATE_CONNECTED
-     * @see ConnectionInterface::STATE_AUTHENTICATED
-     * @see ConnectionInterface::STATE_CLOSEING
-     * @see ConnectionInterface::STATE_CLOSED
-     */
-    public function getState();
 
     /**
      * Quits (soft-close) the connection.

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -147,27 +147,6 @@ interface ConnectionInterface
     public function ping();
 
     /**
-     * Change connection option parameter.
-     *
-     * @param string $name  Parameter name.
-     * @param mixed  $value New value.
-     *
-     * @return ConnectionInterface
-     */
-    public function setOption($name, $value);
-
-    /**
-     * Get connection parameter value.
-     *
-     * @param string $name    Parameter which should be returned.
-     * @param mixed  $default Value which should be returned if parameter is not
-     *                        set.
-     *
-     * @return mixed
-     */
-    public function getOption($name, $default = null);
-
-    /**
      * Information about the server with which the connection is established.
      *
      * Available:

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -147,21 +147,6 @@ interface ConnectionInterface
     public function ping();
 
     /**
-     * Information about the server with which the connection is established.
-     *
-     * Available:
-     *
-     *  * serverVersion
-     *  * threadId
-     *  * ServerCaps
-     *  * serverLang
-     *  * serverStatus
-     *
-     * @return array
-     */
-    public function getServerOptions();
-
-    /**
      * Quits (soft-close) the connection.
      *
      * This method returns a promise that will resolve (with a void value) on

--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -26,6 +26,15 @@ use React\Stream\ThroughStream;
  */
 class Connection extends EventEmitter implements ConnectionInterface
 {
+    const STATE_INIT                = 0;
+    const STATE_CONNECT_FAILED      = 1;
+    const STATE_AUTHENTICATE_FAILED = 2;
+    const STATE_CONNECTING          = 3;
+    const STATE_CONNECTED           = 4;
+    const STATE_AUTHENTICATED       = 5;
+    const STATE_CLOSEING            = 6;
+    const STATE_CLOSED              = 7;
+
     /**
      * @var LoopInterface
      */
@@ -205,14 +214,6 @@ class Connection extends EventEmitter implements ConnectionInterface
         }
 
         return $default;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getState()
-    {
-        return $this->state;
     }
 
     public function quit()

--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -194,28 +194,6 @@ class Connection extends EventEmitter implements ConnectionInterface
         });
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setOption($name, $value)
-    {
-        $this->options[$name] = $value;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getOption($name, $default = null)
-    {
-        if (isset($this->options[$name])) {
-            return $this->options[$name];
-        }
-
-        return $default;
-    }
-
     public function quit()
     {
         return new Promise(function ($resolve, $reject) {

--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -267,14 +267,6 @@ class Connection extends EventEmitter implements ConnectionInterface
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function getServerOptions()
-    {
-        return $this->serverOptions;
-    }
-
-    /**
      * @param Exception $err Error from socket.
      *
      * @return void

--- a/tests/Io/ConnectionTest.php
+++ b/tests/Io/ConnectionTest.php
@@ -18,7 +18,6 @@ class ConnectionTest extends BaseTestCase
 
         $conn->doConnect(function ($err, $conn) use ($loop, $options) {
             $this->assertInstanceOf('React\MySQL\Io\Connection', $conn);
-            $this->assertEquals(Connection::STATE_CONNECT_FAILED, $conn->getState());
         });
         $loop->run();
     }
@@ -37,7 +36,6 @@ class ConnectionTest extends BaseTestCase
                 $err->getMessage()
             );
             $this->assertInstanceOf('React\MySQL\Io\Connection', $conn);
-            $this->assertEquals(Connection::STATE_AUTHENTICATE_FAILED, $conn->getState());
         });
         $loop->run();
     }
@@ -278,14 +276,13 @@ class ConnectionTest extends BaseTestCase
         $conn->doConnect(function ($err, $conn) use ($loop) {
             $this->assertEquals(null, $err);
             $this->assertInstanceOf('React\MySQL\Io\Connection', $conn);
-            $this->assertEquals(Connection::STATE_AUTHENTICATED, $conn->getState());
         });
 
-        $conn->ping()->then(function () use ($loop, $conn) {
-            $conn->quit()->done(function () use ($conn) {
-                $this->assertEquals($conn::STATE_CLOSED, $conn->getState());
-            });
+        $once = $this->expectCallableOnce();
+        $conn->ping()->then(function () use ($conn, $once) {
+            $conn->quit()->then($once);
         });
+
         $loop->run();
     }
 }


### PR DESCRIPTION
This simple PR removes the (mostly under-documented) `getState()`, `getOptions()`, `setOptions()` and `getConnectionOptions()` methods from the `ConnectionInterface`. As of #64 and #65 the connection state is handled internally and is nothing consumers should have to worry about. Similarly, this now uses a URI for connecting instead of connection options.

This is a BC break obviously, but empirical evidence including our examples suggests this should not affect most consumers.

Builds on top of #64 and #65