### PR TITLE
Internal refactoring to simplify connection and authentication logic

### DIFF
--- a/src/Commands/AbstractCommand.php
+++ b/src/Commands/AbstractCommand.php
@@ -125,9 +125,4 @@ abstract class AbstractCommand extends EventEmitter implements CommandInterface
      * mysql_stmt_fetch
      */
     const STMT_FETCH = 0x1c;
-
-    /**
-     * Authenticate after the connection is established, only for this project.
-     */
-    const INIT_AUTHENTICATE = 0xf1;
 }

--- a/src/Commands/AuthenticateCommand.php
+++ b/src/Commands/AuthenticateCommand.php
@@ -2,17 +2,58 @@
 
 namespace React\MySQL\Commands;
 
+use React\MySQL\Io\Buffer;
+use React\MySQL\Io\Constants;
+
 /**
  * @internal
  */
 class AuthenticateCommand extends AbstractCommand
 {
-    public function getId()
+    private $user;
+    private $passwd;
+    private $dbname;
+
+    private $maxPacketSize = 0x1000000;
+    private $charsetNumber = 0x21;
+
+    public function __construct($user, $passwd, $dbname)
     {
-        return self::INIT_AUTHENTICATE;
+        $this->user = $user;
+        $this->passwd = $passwd;
+        $this->dbname = $dbname;
     }
 
-    public function buildPacket()
+    public function getId()
     {
+        return 0;
+    }
+
+    public function authenticatePacket($scramble, Buffer $buffer)
+    {
+        $clientFlags = Constants::CLIENT_LONG_PASSWORD |
+            Constants::CLIENT_LONG_FLAG |
+            Constants::CLIENT_LOCAL_FILES |
+            Constants::CLIENT_PROTOCOL_41 |
+            Constants::CLIENT_INTERACTIVE |
+            Constants::CLIENT_TRANSACTIONS |
+            Constants::CLIENT_SECURE_CONNECTION |
+            Constants::CLIENT_CONNECT_WITH_DB;
+
+        return pack('VVc', $clientFlags, $this->maxPacketSize, $this->charsetNumber)
+            . "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+            . $this->user . "\x00"
+            . $this->getAuthToken($scramble, $this->passwd, $buffer)
+            . ($this->dbname ? $this->dbname . "\x00" : '');
+    }
+
+    public function getAuthToken($scramble, $password, Buffer $buffer)
+    {
+        if ($password === '') {
+            return "\x00";
+        }
+        $token = \sha1($scramble . \sha1($hash1 = \sha1($password, true), true), true) ^ $hash1;
+
+        return $buffer->buildStringLen($token);
     }
 }

--- a/src/Commands/CommandInterface.php
+++ b/src/Commands/CommandInterface.php
@@ -9,6 +9,5 @@ use Evenement\EventEmitterInterface;
  */
 interface CommandInterface extends EventEmitterInterface
 {
-    public function buildPacket();
     public function getId();
 }

--- a/src/Commands/PingCommand.php
+++ b/src/Commands/PingCommand.php
@@ -12,10 +12,6 @@ class PingCommand extends AbstractCommand
         return self::PING;
     }
 
-    public function buildPacket()
-    {
-    }
-
     public function getSql()
     {
         return '';

--- a/src/Commands/QueryCommand.php
+++ b/src/Commands/QueryCommand.php
@@ -45,8 +45,4 @@ class QueryCommand extends AbstractCommand
 
         return $query;
     }
-
-    public function buildPacket()
-    {
-    }
 }

--- a/src/Commands/QuitCommand.php
+++ b/src/Commands/QuitCommand.php
@@ -12,10 +12,6 @@ class QuitCommand extends AbstractCommand
         return self::QUIT;
     }
 
-    public function buildPacket()
-    {
-    }
-
     public function getSql()
     {
         return '';

--- a/src/Io/Executor.php
+++ b/src/Io/Executor.php
@@ -33,11 +33,4 @@ class Executor extends EventEmitter
     {
         return $this->queue->dequeue();
     }
-
-    public function undequeue($command)
-    {
-        $this->queue->unshift($command);
-
-        return $command;
-    }
 }

--- a/tests/Io/ConnectionTest.php
+++ b/tests/Io/ConnectionTest.php
@@ -3,286 +3,64 @@
 namespace React\Tests\MySQL\Io;
 
 use React\MySQL\Io\Connection;
-use React\Socket\Server;
 use React\Tests\MySQL\BaseTestCase;
 
 class ConnectionTest extends BaseTestCase
 {
-    public function testConnectWithInvalidHostRejectsWithConnectionError()
+    public function testQuitWillEnqueueOneCommand()
     {
-        $options = $this->getConnectionOptions();
-        $loop = \React\EventLoop\Factory::create();
-        $conn = new Connection($loop, array('host' => 'example.invalid') + $options);
+        $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(array('enqueue'))->getMock();
+        $executor->expects($this->once())->method('enqueue')->willReturnArgument(0);
 
-        $conn->on('error', $this->expectCallableOnce());
-
-        $conn->doConnect(function ($err, $conn) use ($loop, $options) {
-            $this->assertInstanceOf('React\MySQL\Io\Connection', $conn);
-        });
-        $loop->run();
+        $conn = new Connection($stream, $executor);
+        $conn->quit();
     }
 
-    public function testConnectWithInvalidPassRejectsWithAuthenticationError()
+    public function testQueryAfterQuitRejectsImmediately()
     {
-        $options = $this->getConnectionOptions();
-        $loop = \React\EventLoop\Factory::create();
-        $conn = new Connection($loop, array('passwd' => 'invalidpass') + $options);
+        $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(array('enqueue'))->getMock();
+        $executor->expects($this->once())->method('enqueue')->willReturnArgument(0);
 
-        $conn->on('error', $this->expectCallableOnce());
-
-        $conn->doConnect(function ($err, $conn) use ($loop) {
-            $this->assertRegExp(
-                "/^Access denied for user '.*?'@'.*?' \(using password: YES\)$/",
-                $err->getMessage()
-            );
-            $this->assertInstanceOf('React\MySQL\Io\Connection', $conn);
-        });
-        $loop->run();
+        $conn = new Connection($stream, $executor);
+        $conn->quit();
+        $conn->query('SELECT 1')->then(null, $this->expectCallableOnce());
     }
 
     /**
      * @expectedException React\MySQL\Exception
-     * @expectedExceptionMessage Connection not in idle state
      */
-    public function testConnectTwiceThrowsExceptionForSecondCall()
+    public function testQueryStreamAfterQuitThrows()
     {
-        $options = $this->getConnectionOptions();
-        $loop = \React\EventLoop\Factory::create();
-        $conn = new Connection($loop, $options);
+        $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(array('enqueue'))->getMock();
+        $executor->expects($this->once())->method('enqueue')->willReturnArgument(0);
 
-        $conn->doConnect(function () { });
-        $conn->doConnect(function () { });
-    }
-
-    public function testQuitWithoutConnectRejects()
-    {
-        $options = $this->getConnectionOptions();
-        $loop = \React\EventLoop\Factory::create();
-        $conn = new Connection($loop, $options);
-
-        $conn->quit()->done(
-            $this->expectCallableNever(),
-            function (\Exception $error) {
-                $this->assertInstanceOf('React\MySQL\Exception', $error);
-                $this->assertSame('Can\'t send command', $error->getMessage());
-            }
-        );
-    }
-
-    public function testQueryWithoutConnectRejects()
-    {
-        $options = $this->getConnectionOptions();
-        $loop = \React\EventLoop\Factory::create();
-        $conn = new Connection($loop, $options);
-
-        $conn->query('SELECT 1')->then(
-            $this->expectCallableNever(),
-            function (\Exception $error) {
-                $this->assertInstanceOf('React\MySQL\Exception', $error);
-                $this->assertSame('Can\'t send command', $error->getMessage());
-            }
-        );
-    }
-
-    public function testPingWithoutConnectRejects()
-    {
-        $options = $this->getConnectionOptions();
-        $loop = \React\EventLoop\Factory::create();
-        $conn = new Connection($loop, $options);
-
-        $conn->ping()->done(
-            $this->expectCallableNever(),
-            function (\Exception $error) {
-                $this->assertInstanceOf('React\MySQL\Exception', $error);
-                $this->assertSame('Can\'t send command', $error->getMessage());
-            }
-        );
-    }
-
-    public function testQuitWhileConnectingWillBeQueuedAfterConnection()
-    {
-        $this->expectOutputString('connectedclosed');
-        $options = $this->getConnectionOptions();
-        $loop = \React\EventLoop\Factory::create();
-        $conn = new Connection($loop, $options);
-
-        $conn->doConnect(function ($err) {
-            echo $err ? $err : 'connected';
-        });
-        $conn->quit()->then(function () {
-            echo 'closed';
-        });
-
-        $loop->run();
-    }
-
-    public function testQuitAfterQuitWhileConnectingWillBeRejected()
-    {
-        $options = $this->getConnectionOptions();
-        $loop = \React\EventLoop\Factory::create();
-        $conn = new Connection($loop, $options);
-
-        $conn->doConnect(function ($err) { });
+        $conn = new Connection($stream, $executor);
         $conn->quit();
-
-        $conn->quit()->done(
-            $this->expectCallableNever(),
-            function (\Exception $error) {
-                $this->assertInstanceOf('React\MySQL\Exception', $error);
-                $this->assertSame('Can\'t send command', $error->getMessage());
-            }
-        );
-
-        $loop->run();
+        $conn->queryStream('SELECT 1');
     }
 
-    public function testConnectWillEmitErrorWhenServerClosesConnection()
+    public function testPingAfterQuitRejectsImmediately()
     {
-        $this->expectOutputString('Connection lost');
+        $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(array('enqueue'))->getMock();
+        $executor->expects($this->once())->method('enqueue')->willReturnArgument(0);
 
-        $loop = \React\EventLoop\Factory::create();
-
-        $server = new Server(0, $loop);
-        $server->on('connection', function ($connection) use ($server) {
-            $server->close();
-            $connection->close();
-        });
-
-        $parts = parse_url($server->getAddress());
-        $options = $this->getConnectionOptions();
-        $options['host'] = $parts['host'];
-        $options['port'] = $parts['port'];
-
-        $conn = new Connection($loop, $options);
-
-        $conn->doConnect(function ($err) {
-            echo $err ? $err->getMessage() : 'OK';
-        });
-
-        $loop->run();
+        $conn = new Connection($stream, $executor);
+        $conn->quit();
+        $conn->ping()->then(null, $this->expectCallableOnce());
     }
 
-    public function testPingAfterConnectWillEmitErrorWhenServerClosesConnection()
+    public function testQuitAfterQuitRejectsImmediately()
     {
-        $this->expectOutputString('Connection lost');
+        $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(array('enqueue'))->getMock();
+        $executor->expects($this->once())->method('enqueue')->willReturnArgument(0);
 
-        $loop = \React\EventLoop\Factory::create();
-
-        $server = new Server(0, $loop);
-        $server->on('connection', function ($connection) use ($server) {
-            $server->close();
-            $connection->close();
-        });
-
-        $parts = parse_url($server->getAddress());
-        $options = $this->getConnectionOptions();
-        $options['host'] = $parts['host'];
-        $options['port'] = $parts['port'];
-
-        $conn = new Connection($loop, $options);
-
-        $conn->doConnect(function () { });
-        $conn->ping()->then(
-            $this->expectCallableNever(),
-            function ($err) {
-                echo $err->getMessage();
-            }
-        );
-
-        $loop->run();
-    }
-
-    public function testPingAndQuitWhileConnectingWillBeQueuedAfterConnection()
-    {
-        $this->expectOutputString('connectedpingclosed');
-        $options = $this->getConnectionOptions();
-        $loop = \React\EventLoop\Factory::create();
-        $conn = new Connection($loop, $options);
-
-        $conn->doConnect(function ($err) {
-            echo $err ? $err : 'connected';
-        });
-        $conn->ping()->then(function () {
-            echo 'ping';
-        }, function () {
-            echo $err;
-        });
-        $conn->quit()->then(function () {
-            echo 'closed';
-        });
-
-        $loop->run();
-    }
-
-    public function testPingAfterQuitWhileConnectingRejectsImmediately()
-    {
-        $this->expectOutputString('connectedclosed');
-        $options = $this->getConnectionOptions();
-        $loop = \React\EventLoop\Factory::create();
-        $conn = new Connection($loop, $options);
-
-        $conn->doConnect(function ($err) {
-            echo $err ? $err : 'connected';
-        });
-        $conn->quit()->then(function () {
-            echo 'closed';
-        });
-
-        $failed = false;
-        $conn->ping()->then(null, function () use (&$failed) {
-            $failed = true;
-        });
-        $this->assertTrue($failed);
-
-        $loop->run();
-    }
-
-    public function testQuitWhileConnectingWithInvalidPassWillNeverFire()
-    {
-        $this->expectOutputString('error');
-        $options = $this->getConnectionOptions();
-        $loop = \React\EventLoop\Factory::create();
-        $conn = new Connection($loop, array('passwd' => 'invalidpass') + $options);
-
-        $conn->doConnect(function ($err) {
-            echo $err ? 'error' : 'connected';
-        });
-        $conn->quit()->then(function () {
-            echo 'never';
-        });
-
-        $loop->run();
-    }
-
-    public function testConnectWithValidPass()
-    {
-        $this->expectOutputString('endclose');
-
-        $loop = \React\EventLoop\Factory::create();
-        $conn = new Connection($loop, $this->getConnectionOptions());
-
-        $conn->on('error', $this->expectCallableNever());
-
-        $conn->on('end', function ($conn){
-            $this->assertInstanceOf('React\MySQL\Io\Connection', $conn);
-            echo 'end';
-        });
-
-        $conn->on('close', function ($conn){
-            $this->assertInstanceOf('React\MySQL\Io\Connection', $conn);
-            echo 'close';
-        });
-
-        $conn->doConnect(function ($err, $conn) use ($loop) {
-            $this->assertEquals(null, $err);
-            $this->assertInstanceOf('React\MySQL\Io\Connection', $conn);
-        });
-
-        $once = $this->expectCallableOnce();
-        $conn->ping()->then(function () use ($conn, $once) {
-            $conn->quit()->then($once);
-        });
-
-        $loop->run();
+        $conn = new Connection($stream, $executor);
+        $conn->quit();
+        $conn->quit()->then(null, $this->expectCallableOnce());
     }
 }

--- a/tests/Io/ParserTest.php
+++ b/tests/Io/ParserTest.php
@@ -37,7 +37,9 @@ class ParserTest extends BaseTestCase
         $command->on('error', $this->expectCallableOnce());
 
         // hack to inject command as current command
-        $parser->setOptions(array('currCommand' => $command));
+        $ref = new \ReflectionProperty($parser, 'currCommand');
+        $ref->setAccessible(true);
+        $ref->setValue($parser, $command);
 
         $stream->close();
     }


### PR DESCRIPTION
This PR simplifies connection logic by moving to Factory and authentication logic by moving to AuthenticateCommand. This is a prerequisite for a follow-up PR that introduces improved connection stream handling and a `close()` method (refs #65). It does not affect any of the outside behavior, so this is not a BC break.

Builds on top of #64 and #65