### PR TITLE
Issue 70 Null current command after calling promise resolver

### DIFF
--- a/src/Io/Parser.php
+++ b/src/Io/Parser.php
@@ -293,21 +293,23 @@ field:
     protected function onError()
     {
         $command = $this->currCommand;
-        $this->currCommand = null;
 
         $error = new Exception($this->errmsg, $this->errno);
         $this->errmsg = '';
         $this->errno  = 0;
         $command->emit('error', array($error));
+
+        $this->currCommand = null;
     }
 
     protected function onResultDone()
     {
         $command = $this->currCommand;
-        $this->currCommand = null;
 
         $command->resultFields = $this->resultFields;
         $command->emit('end');
+
+        $this->currCommand = null;
 
         $this->rsState      = self::RS_STATE_HEADER;
         $this->resultFields = [];
@@ -316,7 +318,6 @@ field:
     protected function onSuccess()
     {
         $command = $this->currCommand;
-        $this->currCommand = null;
 
         if ($command instanceof QueryCommand) {
             $command->affectedRows = $this->affectedRows;
@@ -325,6 +326,8 @@ field:
             $command->message      = $this->message;
         }
         $command->emit('success');
+
+        $this->currCommand = null;
     }
 
     protected function onClose()


### PR DESCRIPTION
It's possible that the promise resolve function may also contain a call to query. If we call this after we null the current command, then the new command is immediately queued and dequeued in "nextRequest". We then call nextRequest in the flow for the first query, which overwrites the current query (the second one that was pushed in by the resolver), with the third query. The next result the parser receives is for the second query, not the third, but the "current command" is now the third.

Making sure that we null the current command after we call its receiver fixes the issue, as when the second query is queued, current command is not null, so we don't call nextRequest.