### PR TITLE
Fix executing queued commands in the order they are enqueued

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -128,9 +128,7 @@ class Factory
 
             return new Promise(function ($resolve, $reject) use ($command, $connection, $stream) {
                 $command->on('success', function () use ($resolve, $connection) {
-                    $this->loop->futureTick(function () use ($resolve, $connection) {
-                        $resolve($connection);
-                    });
+                    $resolve($connection);
                 });
                 $command->on('error', function ($error) use ($reject, $stream) {
                     $reject($error);

--- a/tests/NoResultQueryTest.php
+++ b/tests/NoResultQueryTest.php
@@ -59,4 +59,26 @@ class NoResultQueryTest extends BaseTestCase
         $connection->quit();
         $loop->run();
     }
+
+    public function testPingMultipleWillBeExecutedInSameOrderTheyAreEnqueuedFromHandlers()
+    {
+        $this->expectOutputString('123');
+
+        $loop = \React\EventLoop\Factory::create();
+        $connection = $this->createConnection($loop);
+
+        $connection->ping()->then(function () use ($connection) {
+            echo '1';
+
+            $connection->ping()->then(function () use ($connection) {
+                echo '3';
+                $connection->quit();
+            });
+        });
+        $connection->ping()->then(function () {
+            echo '2';
+        });
+
+        $loop->run();
+    }
 }


### PR DESCRIPTION
This PR fixes #70. This was caused by the `Parser` trying to execute multiple commands at the same time when commands are already queued and a new command is queued from a success handler. When the second command was completed, it would no longer have a reference to the command and would bail out. This is a side effect that was introduced with #52, but the underlying flaw has been present for much longer. The fix ensures we only ever take one command from the queue and then wait for it to finish.

Builds on top of #52
Supersedes / closes #74, thank you @elprawn
Resolves / closes #70