### PR TITLE
Add close() method to force-close the connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ It is written in pure PHP and does not require any extensions.
     * [query()](#query)
     * [queryStream()](#querystream)
     * [ping()](#ping)
+    * [quit()](#quit)
+    * [close()](#close)
 * [Install](#install)
 * [Tests](#tests)
 * [License](#license)
@@ -274,6 +276,22 @@ previous commands are completed.
 $connection->query('CREATE TABLE test ...');
 $connection->quit();
 ```
+
+#### close()
+
+The `close(): void` method can be used to
+force-close the connection.
+
+Unlike the `quit()` method, this method will immediately force-close the
+connection and reject all oustanding commands.
+
+```php
+$connection->close();
+```
+
+Forcefully closing the connection will yield a warning in the server logs
+and should generally only be used as a last resort. See also
+[`quit()`](#quit) as a safe alternative.
 
 ## Install
 

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -163,4 +163,22 @@ interface ConnectionInterface
      * @return PromiseInterface Returns a Promise<void,Exception>
      */
     public function quit();
+
+    /**
+     * Force-close the connection.
+     *
+     * Unlike the `quit()` method, this method will immediately force-close the
+     * connection and reject all oustanding commands.
+     *
+     * ```php
+     * $connection->close();
+     * ```
+     *
+     * Forcefully closing the connection will yield a warning in the server logs
+     * and should generally only be used as a last resort. See also
+     * [`quit()`](#quit) as a safe alternative.
+     *
+     * @return void
+     */
+    public function close();
 }


### PR DESCRIPTION
The original `close()` method was renamed to `quit()` (via #65) to emphasize this method actually sends a "quit" command over the wire once all queued commands are done (it waits for all queued commands, which is also why it now returns a promise). It does not force-close the connection like the stream `close()` method commonly used in @reactphp does. This PR adds a new `close(): void` method which immediately force-closes the underlying connection and rejects all outstanding commands.

Being a new addition to the `ConnectionInterface`, this PR is technically a BC break. Empirical evidence suggests this should not affect most consumers (BC is limited due to #65 anyway).

Builds on top of #69 and #65