### PR TITLE
Add warningCount to QueryResult

### DIFF
--- a/src/Commands/QueryCommand.php
+++ b/src/Commands/QueryCommand.php
@@ -13,7 +13,7 @@ class QueryCommand extends AbstractCommand
     public $fields;
     public $insertId;
     public $affectedRows;
-    public $warnCount;
+    public $warningCount;
 
     public function getId()
     {

--- a/src/Commands/QueryCommand.php
+++ b/src/Commands/QueryCommand.php
@@ -13,6 +13,7 @@ class QueryCommand extends AbstractCommand
     public $fields;
     public $insertId;
     public $affectedRows;
+    public $warnCount;
 
     public function getId()
     {

--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -83,6 +83,8 @@ class Connection extends EventEmitter implements ConnectionInterface
             $result = new QueryResult();
             $result->resultFields = $command->resultFields;
             $result->resultRows = $rows;
+            $result->warnCount = $command->warnCount;
+
             $rows = array();
 
             $deferred->resolve($result);
@@ -96,6 +98,7 @@ class Connection extends EventEmitter implements ConnectionInterface
             $result = new QueryResult();
             $result->affectedRows = $command->affectedRows;
             $result->insertId = $command->insertId;
+            $result->warnCount = $command->warnCount;
 
             $deferred->resolve($result);
         });

--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -83,7 +83,7 @@ class Connection extends EventEmitter implements ConnectionInterface
             $result = new QueryResult();
             $result->resultFields = $command->resultFields;
             $result->resultRows = $rows;
-            $result->warnCount = $command->warnCount;
+            $result->warningCount = $command->warningCount;
 
             $rows = array();
 
@@ -98,7 +98,7 @@ class Connection extends EventEmitter implements ConnectionInterface
             $result = new QueryResult();
             $result->affectedRows = $command->affectedRows;
             $result->insertId = $command->insertId;
-            $result->warnCount = $command->warnCount;
+            $result->warningCount = $command->warningCount;
 
             $deferred->resolve($result);
         });

--- a/src/Io/Parser.php
+++ b/src/Io/Parser.php
@@ -52,7 +52,7 @@ class Parser extends EventEmitter
 
     public $seq = 0;
 
-    public $warnCount;
+    public $warningCount;
     public $message;
 
     protected $serverVersion;
@@ -197,11 +197,11 @@ field:
                 $this->affectedRows = $this->buffer->readIntLen();
                 $this->insertId     = $this->buffer->readIntLen();
                 $this->serverStatus = $this->buffer->readInt2();
-                $this->warnCount    = $this->buffer->readInt2();
+                $this->warningCount    = $this->buffer->readInt2();
 
                 $this->message      = $this->buffer->read($this->pctSize - $len + $this->buffer->length());
 
-                $this->debug(sprintf("AffectedRows: %d, InsertId: %d, WarnCount:%d", $this->affectedRows, $this->insertId, $this->warnCount));
+                $this->debug(sprintf("AffectedRows: %d, InsertId: %d, WarningCount:%d", $this->affectedRows, $this->insertId, $this->warningCount));
                 $this->onSuccess();
                 $this->nextRequest();
             } elseif ($fieldCount === 0xFE) {
@@ -307,7 +307,7 @@ field:
         if ($command instanceof QueryCommand) {
             $command->affectedRows = $this->affectedRows;
             $command->insertId     = $this->insertId;
-            $command->warnCount    = $this->warnCount;
+            $command->warningCount    = $this->warningCount;
             $command->message      = $this->message;
         }
         $command->emit('success');

--- a/src/QueryResult.php
+++ b/src/QueryResult.php
@@ -30,4 +30,10 @@ class QueryResult
      * @var array|null
      */
     public $resultRows;
+
+    /**
+     * number of warnings (if any)
+     * @var int|null
+     */
+    public $warnCount;
 }

--- a/src/QueryResult.php
+++ b/src/QueryResult.php
@@ -35,5 +35,5 @@ class QueryResult
      * number of warnings (if any)
      * @var int|null
      */
-    public $warnCount;
+    public $warningCount;
 }

--- a/tests/NoResultQueryTest.php
+++ b/tests/NoResultQueryTest.php
@@ -60,6 +60,29 @@ class NoResultQueryTest extends BaseTestCase
         $loop->run();
     }
 
+    public function testCreateTableAgainWillAddWarning()
+    {
+        $loop = \React\EventLoop\Factory::create();
+        $connection = $this->createConnection($loop);
+
+        $sql = '
+CREATE TABLE IF NOT EXISTS `book` (
+    `id`      INT(11)      NOT NULL AUTO_INCREMENT,
+    `name`    VARCHAR(255) NOT NULL,
+    `isbn`    VARCHAR(255) NULL,
+    `author`  VARCHAR(255) NULL,
+    `created` INT(11)      NULL,
+    PRIMARY KEY (`id`)
+)';
+
+        $connection->query($sql)->then(function (QueryResult $command) {
+            $this->assertEquals(1, $command->warnCount);
+        });
+
+        $connection->quit();
+        $loop->run();
+    }
+
     public function testPingMultipleWillBeExecutedInSameOrderTheyAreEnqueuedFromHandlers()
     {
         $this->expectOutputString('123');

--- a/tests/NoResultQueryTest.php
+++ b/tests/NoResultQueryTest.php
@@ -76,7 +76,7 @@ CREATE TABLE IF NOT EXISTS `book` (
 )';
 
         $connection->query($sql)->then(function (QueryResult $command) {
-            $this->assertEquals(1, $command->warnCount);
+            $this->assertEquals(1, $command->warningCount);
         });
 
         $connection->quit();


### PR DESCRIPTION
A count of warnings is currently added via `Io\Parser::onSuccess()`. This value is dynamically added as attribute to the instance of `QueryCommand`.

This PR will add this value like `affected_rows` to the `QueryCommand` and `QueryResult` class and adds its actual value (if given) to the instance of these classes.
