### PR TITLE
Fix parsing error message during handshake (Too many connections)

### DIFF
--- a/tests/Io/ParserTest.php
+++ b/tests/Io/ParserTest.php
@@ -7,6 +7,7 @@ use React\MySQL\Io\Executor;
 use React\MySQL\Io\Parser;
 use React\Stream\ThroughStream;
 use React\Tests\MySQL\BaseTestCase;
+use React\MySQL\Exception;
 
 class ParserTest extends BaseTestCase
 {
@@ -33,7 +34,7 @@ class ParserTest extends BaseTestCase
         $parser = new Parser($stream, $executor);
         $parser->start();
 
-        $command = new QueryCommand($connection);
+        $command = new QueryCommand();
         $command->on('error', $this->expectCallableOnce());
 
         // hack to inject command as current command
@@ -42,5 +43,48 @@ class ParserTest extends BaseTestCase
         $ref->setValue($parser, $command);
 
         $stream->close();
+    }
+
+    public function testSendingErrorFrameDuringHandshakeShouldEmitErrorOnFollowingCommand()
+    {
+        $stream = new ThroughStream();
+        $connection = $this->getMockBuilder('React\MySQL\ConnectionInterface')->disableOriginalConstructor()->getMock();
+
+        $command = new QueryCommand();
+        $command->on('error', $this->expectCallableOnce());
+
+        $error = null;
+        $command->on('error', function ($e) use (&$error) {
+            $error = $e;
+        });
+
+        $executor = new Executor($connection);
+        $executor->enqueue($command);
+
+        $parser = new Parser($stream, $executor);
+        $parser->start();
+
+        $stream->write("\x17\0\0\0" . "\xFF" . "\x10\x04" . "Too many connections");
+
+        $this->assertTrue($error instanceof Exception);
+        $this->assertEquals(1040, $error->getCode());
+        $this->assertEquals('Too many connections', $error->getMessage());
+    }
+
+    public function testSendingIncompleteErrorFrameDuringHandshakeShouldNotEmitError()
+    {
+        $stream = new ThroughStream();
+        $connection = $this->getMockBuilder('React\MySQL\ConnectionInterface')->disableOriginalConstructor()->getMock();
+
+        $command = new QueryCommand();
+        $command->on('error', $this->expectCallableNever());
+
+        $executor = new Executor($connection);
+        $executor->enqueue($command);
+
+        $parser = new Parser($stream, $executor);
+        $parser->start();
+
+        $stream->write("\xFF\0\0\0" . "\xFF" . "\x12\x34" . "Some incomplete error message...");
     }
 }


### PR DESCRIPTION
The server may reject an incoming connection during authentication or even before that during the initial connection handshake. The initial handshake error message uses a slightly different message format and also semantically happens *before* executing a command, so we now make sure to properly reject the *following* authentication command.

> Note:
    In case the server sent a ERR packet as first packet it will happen before the client and server negotiated any capabilities. Therefore the ERR packet will not contain the SQL-state.

https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase.html

Resolves / closes #81 