### PR TITLE
Implement "idle" timeout for LazyConnection to close underlying connection when unused and automatically create new underlying connection on demand again

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ This method immediately returns a "virtual" connection implementing the
 interface with your MySQL database. Internally, it lazily creates the
 underlying database connection only on demand once the first request is
 invoked on this instance and will queue all outstanding requests until
-the underlying connection is ready. Additionally, it will keep track of
-this underlying connection and will create a new underlying connection
-on demand when the current connection is lost.
+the underlying connection is ready. Additionally, it will only keep this
+underlying connection in an "idle" state for 60s by default and will
+automatically end the underlying connection when it is no longer needed.
 
 From a consumer side this means that you can start sending queries to the
 database right away while the underlying connection may still be
@@ -189,15 +189,17 @@ having to deal with its async resolution.
 If the underlying database connection fails, it will reject all
 outstanding commands and will return to the initial "idle" state. This
 means that you can keep sending additional commands at a later time which
-will again try to open the underlying connection.
+will again try to open a new underlying connection. Note that this may
+require special care if you're using transactions that are kept open for
+longer than the idle period.
 
 Note that creating the underlying connection will be deferred until the
 first request is invoked. Accordingly, any eventual connection issues
 will be detected once this instance is first used. You can use the
 `quit()` method to ensure that the "virtual" connection will be soft-closed
 and no further commands can be enqueued. Similarly, calling `quit()` on
-this instance before invoking any requests will succeed immediately and
-will not wait for an actual underlying connection.
+this instance when not currently connected will succeed immediately and
+will not have to wait for an actual underlying connection.
 
 Depending on your particular use case, you may prefer this method or the
 underlying `createConnection()` which resolves with a promise. For many
@@ -232,6 +234,19 @@ in seconds (or use a negative number to not apply a timeout) like this:
 
 ```php
 $factory->createLazyConnection('localhost?timeout=0.5');
+```
+
+By default, this method will keep "idle" connection open for 60s and will
+then end the underlying connection. The next request after an "idle"
+connection ended will automatically create a new underlying connection.
+This ensure you always get a "fresh" connection and as such should not be
+confused with a "keepalive" or "heartbeat" mechanism, as this will not
+actively try to probe the connection. You can explicitly pass a custom
+idle timeout value in seconds (or use a negative number to not apply a
+timeout) like this:
+
+```php
+$factory->createLazyConnection('localhost?idle=0.1');
 ```
 
 ### ConnectionInterface
@@ -435,7 +450,7 @@ $connecion->on('close', function () {
 });
 ```
 
-See also the [#close](#close) method.
+See also the [`close()`](#close) method.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -171,24 +171,33 @@ $connection->query(…);
 This method immediately returns a "virtual" connection implementing the
 [`ConnectionInterface`](#connectioninterface) that can be used to
 interface with your MySQL database. Internally, it lazily creates the
-underlying database connection (which may take some time) only once the
-first request is invoked on this instance and will queue all outstanding
-requests until the underlying connection is ready.
+underlying database connection only on demand once the first request is
+invoked on this instance and will queue all outstanding requests until
+the underlying connection is ready. Additionally, it will keep track of
+this underlying connection and will create a new underlying connection
+on demand when the current connection is lost.
 
 From a consumer side this means that you can start sending queries to the
-database right away while the actual connection may still be outstanding.
-It will ensure that all commands will be executed in the order they are
-enqueued once the connection is ready. If the database connection fails,
-it will emit an `error` event, reject all outstanding commands and `close`
-the connection as described in the `ConnectionInterface`. In other words,
-it behaves just like a real connection and frees you from having to deal
-with its async resolution.
+database right away while the underlying connection may still be
+outstanding. Because creating this underlying connection may take some
+time, it will enqueue all oustanding commands and will ensure that all
+commands will be executed in correct order once the connection is ready.
+In other words, this "virtual" connection behaves just like a "real"
+connection as described in the `ConnectionInterface` and frees you from
+having to deal with its async resolution.
+
+If the underlying database connection fails, it will reject all
+outstanding commands and will return to the initial "idle" state. This
+means that you can keep sending additional commands at a later time which
+will again try to open the underlying connection.
 
 Note that creating the underlying connection will be deferred until the
 first request is invoked. Accordingly, any eventual connection issues
-will be detected once this instance is first used. Similarly, calling
-`quit()` on this instance before invoking any requests will succeed
-immediately and will not wait for an actual underlying connection.
+will be detected once this instance is first used. You can use the
+`quit()` method to ensure that the "virtual" connection will be soft-closed
+and no further commands can be enqueued. Similarly, calling `quit()` on
+this instance before invoking any requests will succeed immediately and
+will not wait for an actual underlying connection.
 
 Depending on your particular use case, you may prefer this method or the
 underlying `createConnection()` which resolves with a promise. For many

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.4.0",
         "evenement/evenement": "^3.0 || ^2.1 || ^1.1",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4",
+        "react/event-loop": "^1.0 || ^0.5",
         "react/promise": "^2.7",
         "react/promise-stream": "^1.1",
         "react/promise-timer": "^1.5",

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -38,7 +38,7 @@ use React\Stream\ReadableStreamInterface;
  *     });
  *     ```
  *
- *     See also the [#close](#close) method.
+ *     See also the [`close()`](#close) method.
  */
 interface ConnectionInterface extends EventEmitterInterface
 {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -213,9 +213,9 @@ class Factory
      * interface with your MySQL database. Internally, it lazily creates the
      * underlying database connection only on demand once the first request is
      * invoked on this instance and will queue all outstanding requests until
-     * the underlying connection is ready. Additionally, it will keep track of
-     * this underlying connection and will create a new underlying connection
-     * on demand when the current connection is lost.
+     * the underlying connection is ready. Additionally, it will only keep this
+     * underlying connection in an "idle" state for 60s by default and will
+     * automatically end the underlying connection when it is no longer needed.
      *
      * From a consumer side this means that you can start sending queries to the
      * database right away while the underlying connection may still be
@@ -229,15 +229,17 @@ class Factory
      * If the underlying database connection fails, it will reject all
      * outstanding commands and will return to the initial "idle" state. This
      * means that you can keep sending additional commands at a later time which
-     * will again try to open the underlying connection.
+     * will again try to open a new underlying connection. Note that this may
+     * require special care if you're using transactions that are kept open for
+     * longer than the idle period.
      *
      * Note that creating the underlying connection will be deferred until the
      * first request is invoked. Accordingly, any eventual connection issues
      * will be detected once this instance is first used. You can use the
      * `quit()` method to ensure that the "virtual" connection will be soft-closed
      * and no further commands can be enqueued. Similarly, calling `quit()` on
-     * this instance before invoking any requests will succeed immediately and
-     * will not wait for an actual underlying connection.
+     * this instance when not currently connected will succeed immediately and
+     * will not have to wait for an actual underlying connection.
      *
      * Depending on your particular use case, you may prefer this method or the
      * underlying `createConnection()` which resolves with a promise. For many
@@ -274,11 +276,24 @@ class Factory
      * $factory->createLazyConnection('localhost?timeout=0.5');
      * ```
      *
+     * By default, this method will keep "idle" connection open for 60s and will
+     * then end the underlying connection. The next request after an "idle"
+     * connection ended will automatically create a new underlying connection.
+     * This ensure you always get a "fresh" connection and as such should not be
+     * confused with a "keepalive" or "heartbeat" mechanism, as this will not
+     * actively try to probe the connection. You can explicitly pass a custom
+     * idle timeout value in seconds (or use a negative number to not apply a
+     * timeout) like this:
+     *
+     * ```php
+     * $factory->createLazyConnection('localhost?idle=0.1');
+     * ```
+     *
      * @param string $uri
      * @return ConnectionInterface
      */
     public function createLazyConnection($uri)
     {
-        return new LazyConnection($this, $uri);
+        return new LazyConnection($this, $uri, $this->loop);
     }
 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -387,6 +387,19 @@ class FactoryTest extends BaseTestCase
         $loop->run();
     }
 
+    public function testConnectLazyWithValidAuthWillRunUntilIdleTimerAfterPingEvenWithoutQuit()
+    {
+        $loop = \React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
+
+        $uri = $this->getConnectionString() . '?idle=0';
+        $connection = $factory->createLazyConnection($uri);
+
+        $connection->ping();
+
+        $loop->run();
+    }
+
     public function testConnectLazyWithInvalidAuthWillRejectPingButWillNotEmitErrorOrClose()
     {
         $loop = \React\EventLoop\Factory::create();

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -387,7 +387,7 @@ class FactoryTest extends BaseTestCase
         $loop->run();
     }
 
-    public function testConnectLazyWithInvalidAuthWillEmitErrorAndCloseAfterPing()
+    public function testConnectLazyWithInvalidAuthWillRejectPingButWillNotEmitErrorOrClose()
     {
         $loop = \React\EventLoop\Factory::create();
         $factory = new Factory($loop);
@@ -395,10 +395,10 @@ class FactoryTest extends BaseTestCase
         $uri = $this->getConnectionString(array('passwd' => 'invalidpass'));
         $connection = $factory->createLazyConnection($uri);
 
-        $connection->on('error', $this->expectCallableOnce());
-        $connection->on('close', $this->expectCallableOnce());
+        $connection->on('error', $this->expectCallableNever());
+        $connection->on('close', $this->expectCallableNever());
 
-        $connection->ping();
+        $connection->ping()->then(null, $this->expectCallableOnce());
 
         $loop->run();
     }


### PR DESCRIPTION
By default, the `createLazyConnection()` method will now keep "idle" connection open for 60s and will
then end the underlying connection. The next request after an "idle"
connection ended will automatically create a new underlying connection.
This ensure you always get a "fresh" connection and as such should not be
confused with a "keepalive" or "heartbeat" mechanism, as this will not
actively try to probe the connection. You can explicitly pass a custom
idle timeout value in seconds (or use a negative number to not apply a
timeout) like this:

```php
$factory->createLazyConnection('localhost?idle=0.1');
```

Builds on top of #87 