### PR TITLE
Fix "bad handshake" error when connecting without database name

### DIFF
--- a/src/Commands/AuthenticateCommand.php
+++ b/src/Commands/AuthenticateCommand.php
@@ -44,7 +44,7 @@ class AuthenticateCommand extends AbstractCommand
             . "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
             . $this->user . "\x00"
             . $this->getAuthToken($scramble, $this->passwd, $buffer)
-            . ($this->dbname ? $this->dbname . "\x00" : '');
+            . $this->dbname . "\x00";
     }
 
     public function getAuthToken($scramble, $password, Buffer $buffer)

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -160,6 +160,24 @@ class FactoryTest extends BaseTestCase
         $loop->run();
     }
 
+    public function testConnectWithValidAuthAndWithoutDbNameWillRunUntilQuit()
+    {
+        $this->expectOutputString('connected.closed.');
+
+        $loop = \React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
+
+        $uri = $this->getConnectionString(array('dbname' => ''));
+        $factory->createConnection($uri)->then(function (ConnectionInterface $connection) {
+            echo 'connected.';
+            $connection->quit()->then(function () {
+                echo 'closed.';
+            });
+        }, 'printf')->then(null, 'printf');
+
+        $loop->run();
+    }
+
     public function testConnectWithValidAuthWillIgnoreNegativeTimeoutAndRunUntilQuit()
     {
         $this->expectOutputString('connected.closed.');

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -359,6 +359,25 @@ class ResultQueryTest extends BaseTestCase
         $loop->run();
     }
 
+    /**
+     * @depends testSimpleSelect
+     */
+    public function testSimpleSelectFromLazyConnectionWithoutDatabaseNameReturnsSameData()
+    {
+        $loop = \React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
+
+        $uri = $this->getConnectionString(array('dbname' => ''));
+        $connection = $factory->createLazyConnection($uri);
+
+        $connection->query('select * from test.book')->then(function (QueryResult $command) {
+            $this->assertCount(2, $command->resultRows);
+        })->done();
+
+        $connection->quit();
+        $loop->run();
+    }
+
     public function testInvalidSelectShouldFail()
     {
         $loop = \React\EventLoop\Factory::create();


### PR DESCRIPTION
This simple PR fixes a bug that occurred when trying to connect to the database without giving a database name. While rarely used in practice, this might make sense for admin access to create a database or issue a `use "dbname"` query later on. This previously resulted in an exception with the message "bad handshake" during the connection due to invalid protocol usage.