### PR TITLE
Test against PHP 7.3, add forward compatibility with PHPUnit 7 and use legacy PHPUnit 5 on HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,16 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  - hhvm # ignore errors, see below
+  - 7.3
+# - hhvm # requires legacy phpunit & ignore errors, see below
 
 # lock distro so new future defaults will not break the build
 dist: trusty
 
 matrix:
+  include:
+    - php: hhvm
+      install: composer require phpunit/phpunit:^5 --dev --no-interaction
   allow_failures:
     - php: hhvm
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "clue/block-react": "^1.2",
-        "phpunit/phpunit": "^4.8.35"
+        "phpunit/phpunit": "^7.0 || ^6.0 || ^5.0 || ^4.8.35"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
     <testsuites>

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -405,6 +405,9 @@ class FactoryTest extends BaseTestCase
         $loop->run();
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testConnectLazyWithValidAuthWillRunUntilIdleTimerAfterPingEvenWithoutQuit()
     {
         $loop = \React\EventLoop\Factory::create();

--- a/tests/Io/BufferTest.php
+++ b/tests/Io/BufferTest.php
@@ -2,9 +2,10 @@
 
 namespace React\Tests\MySQL\Io;
 
+use PHPUnit\Framework\TestCase;
 use React\MySQL\Io\Buffer;
 
-class BufferTest extends \PHPUnit_Framework_TestCase
+class BufferTest extends TestCase
 {
     public function testAppendAndReadBinary()
     {

--- a/tests/Io/QueryTest.php
+++ b/tests/Io/QueryTest.php
@@ -2,9 +2,10 @@
 
 namespace React\Tests\MySQL\Io;
 
+use PHPUnit\Framework\TestCase;
 use React\MySQL\Io\Query;
 
-class QueryTest extends \PHPUnit_Framework_TestCase
+class QueryTest extends TestCase
 {
     public function testBindParams()
     {


### PR DESCRIPTION
Builds on top of clue/php-socket-raw#42