### PR TITLE
Nullify connecting after canceling the timer

### DIFF
--- a/src/Io/LazyConnection.php
+++ b/src/Io/LazyConnection.php
@@ -60,12 +60,11 @@ class LazyConnection extends EventEmitter implements ConnectionInterface
         $this->connecting->then(function (ConnectionInterface $connection) {
             // connection completed => remember only until closed
             $connection->on('close', function () {
-                $this->connecting = null;
-
                 if ($this->idleTimer !== null) {
                     $this->loop->cancelTimer($this->idleTimer);
                     $this->idleTimer = null;
                 }
+                $this->connecting = null;
             });
         }, function () {
             // connection failed => discard connection attempt


### PR DESCRIPTION
https://github.com/friends-of-reactphp/mysql/pull/106#issuecomment-490419998

> Having a hard time reproducing this.
> 
> What basically happens is the connection closes on the database side, the connection is nullified before the idleTimer is cancelled.
> 
> https://github.com/friends-of-reactphp/mysql/blob/c420ca0d199f2867854508473f5eccecbcb692f1/src/Io/LazyConnection.php#L62-L69
> 
> My script somehow managed to run the idleTimer before the cancelTimer, and after `connecting = null` (yay for async).
> ...

My previous pr would actually trigger a new connection when trying to idle it... This just moves nullifying `connecting` AFTER canceling the `idleTimer`.

I can't seem to reproduce this, it was a one time fluke, which resulted in a fatal error and killed the script.
