### PR TITLE
Do not start idle timer when lazy connection is already closed

### DIFF
--- a/src/Io/LazyConnection.php
+++ b/src/Io/LazyConnection.php
@@ -89,7 +89,7 @@ class LazyConnection extends EventEmitter implements ConnectionInterface
     {
         --$this->pending;
 
-        if ($this->pending < 1 && $this->idlePeriod >= 0) {
+        if ($this->pending < 1 && $this->idlePeriod >= 0 && $this->connecting !== null) {
             $this->idleTimer = $this->loop->addTimer($this->idlePeriod, function () {
                 $this->connecting->then(function (ConnectionInterface $connection) {
                     $this->disconnecting = $connection;


### PR DESCRIPTION
When an operation fails because the underlying connection is closed, we
should never start an idle timer. There used to be a race condition that
the connection close event was detected before cancelling the pending
commands. We avoid this by checking the connection state before starting
an idle timer when an operation fails.

Closes #107 and #106, thanks @choval for reporting!