### PR TITLE
Support optional `charset` parameter for full UTF-8 support (`utf8mb4`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ authentication. You can explicitly pass a custom timeout value in seconds
 $factory->createConnection('localhost?timeout=0.5');
 ```
 
+By default, the connection uses the `utf8` charset encoding. Note that
+MySQL's `utf8` encoding (also known as `utf8mb3`) predates what is now
+known as UTF-8 and for historical reasons doesn't support emojis and
+other characters. If you want full UTF-8 support, you can pass the
+charset encoding like this:
+
+```php
+$factory->createConnection('localhost?charset=utf8mb4');
+```
+
 #### createLazyConnection()
 
 Creates a new connection.
@@ -272,6 +282,16 @@ timeout) like this:
 
 ```php
 $factory->createLazyConnection('localhost?idle=0.1');
+```
+
+By default, the connection uses the `utf8` charset encoding. Note that
+MySQL's `utf8` encoding (also known as `utf8mb3`) predates what is now
+known as UTF-8 and for historical reasons doesn't support emojis and
+other characters. If you want full UTF-8 support, you can pass the
+charset encoding like this:
+
+```php
+$factory->createLazyConnection('localhost?charset=utf8mb4');
 ```
 
 ### ConnectionInterface

--- a/src/Io/Query.php
+++ b/src/Io/Query.php
@@ -13,6 +13,15 @@ class Query
 
     private $params = [];
 
+    /**
+     * Mapping from byte/character to escaped character string
+     *
+     * Note that this mapping assumes an ASCII-compatible charset encoding such
+     * as UTF-8, ISO 8859 and others.
+     *
+     * @var array<string,string>
+     * @see \React\MySQL\Commands\AuthenticateCommand::$charsetMap
+     */
     private $escapeChars = array(
             "\x00"   => "\\0",
             "\r"   => "\\r",

--- a/tests/Commands/AuthenticateCommandTest.php
+++ b/tests/Commands/AuthenticateCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace React\Tests\MySQL\Commands;
+
+use PHPUnit\Framework\TestCase;
+use React\MySQL\Commands\AuthenticateCommand;
+
+class AuthenticateCommandTest extends TestCase
+{
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testCtorWithKnownCharset()
+    {
+        new AuthenticateCommand('Alice', 'secret', '', 'utf8');
+    }
+
+    public function testCtorWithUnknownCharsetThrows()
+    {
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('InvalidArgumentException');
+        } else {
+            // legacy PHPUnit < 5.2
+            $this->setExpectedException('InvalidArgumentException');
+        }
+        new AuthenticateCommand('Alice', 'secret', '', 'utf16');
+    }
+}

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -89,6 +89,19 @@ class FactoryTest extends BaseTestCase
         $promise->then(null, $this->expectCallableOnce());
     }
 
+    public function testConnectWithInvalidCharsetWillRejectWithoutConnecting()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->never())->method('connect');
+
+        $factory = new Factory($loop, $connector);
+        $promise = $factory->createConnection('localhost?charset=unknown');
+
+        $this->assertInstanceof('React\Promise\PromiseInterface', $promise);
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
     public function testConnectWithInvalidHostRejectsWithConnectionError()
     {
         $loop = \React\EventLoop\Factory::create();

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -340,6 +340,39 @@ class ResultQueryTest extends BaseTestCase
         $loop->run();
     }
 
+    public function testSelectCharsetDefaultsToUtf8()
+    {
+        $loop = \React\EventLoop\Factory::create();
+        $connection = $this->createConnection($loop);
+
+        $connection->query('SELECT @@character_set_client')->then(function (QueryResult $command) {
+            $this->assertCount(1, $command->resultRows);
+            $this->assertCount(1, $command->resultRows[0]);
+            $this->assertSame('utf8', reset($command->resultRows[0]));
+        });
+
+        $connection->quit();
+        $loop->run();
+    }
+
+    public function testSelectWithExplcitCharsetReturnsCharset()
+    {
+        $loop = \React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
+
+        $uri = $this->getConnectionString() . '?charset=latin1';
+        $connection = $factory->createLazyConnection($uri);
+
+        $connection->query('SELECT @@character_set_client')->then(function (QueryResult $command) {
+            $this->assertCount(1, $command->resultRows);
+            $this->assertCount(1, $command->resultRows[0]);
+            $this->assertSame('latin1', reset($command->resultRows[0]));
+        });
+
+        $connection->quit();
+        $loop->run();
+    }
+
     public function testSimpleSelect()
     {
         $loop = \React\EventLoop\Factory::create();


### PR DESCRIPTION
This changeset adds support for an optional `charset` parameter for full UTF-8 support (`utf8mb4`).

By default, the connection uses the `utf8` charset encoding. Note that
MySQL's `utf8` encoding (also known as `utf8mb3`) predates what is now
known as UTF-8 and for historical reasons doesn't support emojis and
other characters. If you want full UTF-8 support, you can pass the
charset encoding like this:

```php
$factory->createLazyConnection('localhost?charset=utf8mb4');
```

Resolves / closes #133
Refs #131