### PR TITLE
Simplify usage by supporting new Socket API and use new deafult loop in test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ proxy servers etc.), you can explicitly pass a custom instance of the
 [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
 
 ```php
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'dns' => '127.0.0.1',
     'tcp' => array(
         'bindto' => '192.168.10.1:0'

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "react/promise": "^2.7",
         "react/promise-stream": "^1.1",
         "react/promise-timer": "^1.5",
-        "react/socket": "^1.8"
+        "react/socket": "^1.9"
     },
     "require-dev": {
         "clue/block-react": "^1.2",

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -42,7 +42,7 @@ class Factory
      * [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
      *
      * ```php
-     * $connector = new React\Socket\Connector(null, array(
+     * $connector = new React\Socket\Connector(array(
      *     'dns' => '127.0.0.1',
      *     'tcp' => array(
      *         'bindto' => '192.168.10.1:0'
@@ -62,7 +62,7 @@ class Factory
     public function __construct(LoopInterface $loop = null, ConnectorInterface $connector = null)
     {
         $this->loop = $loop ?: Loop::get();
-        $this->connector = $connector ?: new Connector($this->loop);
+        $this->connector = $connector ?: new Connector(array(), $this->loop);
     }
 
     /**

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -95,7 +95,7 @@ class Factory
      * ```php
      * $promise = $factory->createConnection($url);
      *
-     * $loop->addTimer(3.0, function () use ($promise) {
+     * Loop::addTimer(3.0, function () use ($promise) {
      *     $promise->cancel();
      * });
      * ```

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace React\Tests\MySQL;
 
+use React\EventLoop\Loop;
 use React\MySQL\ConnectionInterface;
 use React\MySQL\Factory;
 use React\Socket\SocketServer;
@@ -104,21 +105,19 @@ class FactoryTest extends BaseTestCase
 
     public function testConnectWithInvalidHostRejectsWithConnectionError()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString(array('host' => 'example.invalid'));
         $promise = $factory->createConnection($uri);
 
         $promise->then(null, $this->expectCallableOnce());
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testConnectWithInvalidPassRejectsWithAuthenticationError()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString(array('passwd' => 'invalidpass'));
         $promise = $factory->createConnection($uri);
@@ -132,15 +131,14 @@ class FactoryTest extends BaseTestCase
             )
         ));
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testConnectWillRejectWhenServerClosesConnection()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
-        $socket = new SocketServer('127.0.0.1:0', array(), $loop);
+        $socket = new SocketServer('127.0.0.1:0', array());
         $socket->on('connection', function ($connection) use ($socket) {
             $socket->close();
             $connection->close();
@@ -152,13 +150,12 @@ class FactoryTest extends BaseTestCase
         $promise = $factory->createConnection($uri);
         $promise->then(null, $this->expectCallableOnce());
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testConnectWillRejectOnExplicitTimeoutDespiteValidAuth()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString() . '?timeout=0';
 
@@ -173,13 +170,12 @@ class FactoryTest extends BaseTestCase
             )
         ));
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testConnectWillRejectOnDefaultTimeoutFromIniDespiteValidAuth()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString();
 
@@ -197,15 +193,14 @@ class FactoryTest extends BaseTestCase
             )
         ));
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testConnectWithValidAuthWillRunUntilQuit()
     {
         $this->expectOutputString('connected.closed.');
 
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString();
         $factory->createConnection($uri)->then(function (ConnectionInterface $connection) {
@@ -215,15 +210,14 @@ class FactoryTest extends BaseTestCase
             });
         }, 'printf')->then(null, 'printf');
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testConnectWithValidAuthAndWithoutDbNameWillRunUntilQuit()
     {
         $this->expectOutputString('connected.closed.');
 
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString(array('dbname' => ''));
         $factory->createConnection($uri)->then(function (ConnectionInterface $connection) {
@@ -233,15 +227,14 @@ class FactoryTest extends BaseTestCase
             });
         }, 'printf')->then(null, 'printf');
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testConnectWithValidAuthWillIgnoreNegativeTimeoutAndRunUntilQuit()
     {
         $this->expectOutputString('connected.closed.');
 
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString() . '?timeout=-1';
         $factory->createConnection($uri)->then(function (ConnectionInterface $connection) {
@@ -251,15 +244,14 @@ class FactoryTest extends BaseTestCase
             });
         }, 'printf')->then(null, 'printf');
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testConnectWithValidAuthCanPingAndThenQuit()
     {
         $this->expectOutputString('connected.ping.closed.');
 
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString();
         $factory->createConnection($uri)->then(function (ConnectionInterface $connection) {
@@ -273,15 +265,14 @@ class FactoryTest extends BaseTestCase
 
         }, 'printf')->then(null, 'printf');
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testConnectWithValidAuthCanQueuePingAndQuit()
     {
         $this->expectOutputString('connected.ping.closed.');
 
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString();
         $factory->createConnection($uri)->then(function (ConnectionInterface $connection) {
@@ -294,15 +285,14 @@ class FactoryTest extends BaseTestCase
             });
         }, 'printf')->then(null, 'printf');
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testConnectWithValidAuthQuitOnlyOnce()
     {
         $this->expectOutputString('connected.closed.');
 
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString();
         $factory->createConnection($uri)->then(function (ConnectionInterface $connection) {
@@ -315,15 +305,14 @@ class FactoryTest extends BaseTestCase
             });
         }, 'printf')->then(null, 'printf');
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testConnectWithValidAuthCanCloseOnlyOnce()
     {
         $this->expectOutputString('connected.closed.');
 
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString();
         $factory->createConnection($uri)->then(function (ConnectionInterface $connection) {
@@ -339,15 +328,14 @@ class FactoryTest extends BaseTestCase
             $connection->close();
         }, 'printf')->then(null, 'printf');
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testConnectWithValidAuthCanCloseAndAbortPing()
     {
         $this->expectOutputString('connected.aborted pending (Connection lost).aborted queued (Connection lost).closed.');
 
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString();
         $factory->createConnection($uri)->then(function (ConnectionInterface $connection) {
@@ -368,7 +356,7 @@ class FactoryTest extends BaseTestCase
             $connection->close();
         }, 'printf')->then(null, 'printf');
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testCancelConnectWillCancelPendingConnection()
@@ -433,8 +421,7 @@ class FactoryTest extends BaseTestCase
     {
         $this->expectOutputString('closed.');
 
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = 'mysql://random:pass@host';
         $connection = $factory->createLazyConnection($uri);
@@ -448,8 +435,7 @@ class FactoryTest extends BaseTestCase
     {
         $this->expectOutputString('closed.');
 
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString();
         $connection = $factory->createLazyConnection($uri);
@@ -460,7 +446,7 @@ class FactoryTest extends BaseTestCase
             echo 'closed.';
         });
 
-        $loop->run();
+        Loop::run();
     }
 
     /**
@@ -468,21 +454,19 @@ class FactoryTest extends BaseTestCase
      */
     public function testConnectLazyWithValidAuthWillRunUntilIdleTimerAfterPingEvenWithoutQuit()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString() . '?idle=0';
         $connection = $factory->createLazyConnection($uri);
 
         $connection->ping();
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testConnectLazyWithInvalidAuthWillRejectPingButWillNotEmitErrorOrClose()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString(array('passwd' => 'invalidpass'));
         $connection = $factory->createLazyConnection($uri);
@@ -492,15 +476,14 @@ class FactoryTest extends BaseTestCase
 
         $connection->ping()->then(null, $this->expectCallableOnce());
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testConnectLazyWithValidAuthWillPingBeforeQuitButNotAfter()
     {
         $this->expectOutputString('ping.closed.');
 
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString();
         $connection = $factory->createLazyConnection($uri);
@@ -517,6 +500,6 @@ class FactoryTest extends BaseTestCase
             echo 'never reached';
         });
 
-        $loop->run();
+        Loop::run();
     }
 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -4,7 +4,7 @@ namespace React\Tests\MySQL;
 
 use React\MySQL\ConnectionInterface;
 use React\MySQL\Factory;
-use React\Socket\Server;
+use React\Socket\SocketServer;
 use React\Promise\Promise;
 
 class FactoryTest extends BaseTestCase
@@ -140,13 +140,13 @@ class FactoryTest extends BaseTestCase
         $loop = \React\EventLoop\Factory::create();
         $factory = new Factory($loop);
 
-        $server = new Server(0, $loop);
-        $server->on('connection', function ($connection) use ($server) {
-            $server->close();
+        $socket = new SocketServer('127.0.0.1:0', array(), $loop);
+        $socket->on('connection', function ($connection) use ($socket) {
+            $socket->close();
             $connection->close();
         });
 
-        $parts = parse_url($server->getAddress());
+        $parts = parse_url($socket->getAddress());
         $uri = $this->getConnectionString(array('host' => $parts['host'], 'port' => $parts['port']));
 
         $promise = $factory->createConnection($uri);

--- a/tests/NoResultQueryTest.php
+++ b/tests/NoResultQueryTest.php
@@ -2,40 +2,38 @@
 
 namespace React\Tests\MySQL;
 
+use React\EventLoop\Loop;
 use React\MySQL\QueryResult;
 
 class NoResultQueryTest extends BaseTestCase
 {
     public function setUp()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         // re-create test "book" table
         $connection->query('DROP TABLE IF EXISTS book');
         $connection->query($this->getDataTable());
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testUpdateSimpleNonExistentReportsNoAffectedRows()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('update book set created=999 where id=999')->then(function (QueryResult $command) {
             $this->assertEquals(0, $command->affectedRows);
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testInsertSimpleReportsFirstInsertId()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query("insert into book (`name`) values ('foo')")->then(function (QueryResult $command) {
             $this->assertEquals(1, $command->affectedRows);
@@ -43,13 +41,12 @@ class NoResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testUpdateSimpleReportsAffectedRow()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query("insert into book (`name`) values ('foo')");
         $connection->query('update book set created=999 where id=1')->then(function (QueryResult $command) {
@@ -57,13 +54,12 @@ class NoResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testCreateTableAgainWillAddWarning()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $sql = '
 CREATE TABLE IF NOT EXISTS `book` (
@@ -80,15 +76,14 @@ CREATE TABLE IF NOT EXISTS `book` (
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testPingMultipleWillBeExecutedInSameOrderTheyAreEnqueuedFromHandlers()
     {
         $this->expectOutputString('123');
 
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->ping()->then(function () use ($connection) {
             echo '1';
@@ -102,6 +97,6 @@ CREATE TABLE IF NOT EXISTS `book` (
             echo '2';
         });
 
-        $loop->run();
+        Loop::run();
     }
 }

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -2,6 +2,7 @@
 
 namespace React\Tests\MySQL;
 
+use React\EventLoop\Loop;
 use React\MySQL\Io\Constants;
 use React\MySQL\QueryResult;
 use React\MySQL\Factory;
@@ -10,8 +11,7 @@ class ResultQueryTest extends BaseTestCase
 {
     public function testSelectStaticText()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('select \'foo\'')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
@@ -22,7 +22,7 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function provideValuesThatWillBeReturnedAsIs()
@@ -54,8 +54,7 @@ class ResultQueryTest extends BaseTestCase
      */
     public function testSelectStaticValueWillBeReturnedAsIs($value)
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $expected = $value;
 
@@ -66,7 +65,7 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     /**
@@ -74,8 +73,7 @@ class ResultQueryTest extends BaseTestCase
      */
     public function testSelectStaticValueWillBeConvertedToString($value, $expected)
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('select ?', [$value])->then(function (QueryResult $command) use ($expected) {
             $this->assertCount(1, $command->resultRows);
@@ -84,13 +82,12 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSelectStaticTextWithQuestionMark()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('select \'hello?\'')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
@@ -99,13 +96,12 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSelectLongStaticTextHasTypeStringWithValidLength()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $length = 40000;
         $value = str_repeat('.', $length);
@@ -117,13 +113,12 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSelectStaticTextWithEmptyLabel()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('select \'foo\' as ``')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
@@ -136,13 +131,12 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSelectStaticNullHasTypeNull()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('select null')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
@@ -154,13 +148,12 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSelectStaticTextTwoRows()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('select "foo" UNION select "bar"')->then(function (QueryResult $command) {
             $this->assertCount(2, $command->resultRows);
@@ -171,13 +164,12 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSelectStaticTextTwoRowsWithNullHasTypeString()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('select "foo" UNION select null')->then(function (QueryResult $command) {
             $this->assertCount(2, $command->resultRows);
@@ -191,13 +183,12 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSelectStaticIntegerTwoRowsWithNullHasTypeLongButReturnsIntAsString()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('select 0 UNION select null')->then(function (QueryResult $command) {
             $this->assertCount(2, $command->resultRows);
@@ -211,13 +202,12 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSelectStaticTextTwoRowsWithIntegerHasTypeString()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('select "foo" UNION select 1')->then(function (QueryResult $command) {
             $this->assertCount(2, $command->resultRows);
@@ -231,13 +221,12 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSelectStaticTextTwoRowsWithEmptyRow()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('select "foo" UNION select ""')->then(function (QueryResult $command) {
             $this->assertCount(2, $command->resultRows);
@@ -248,13 +237,12 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSelectStaticTextNoRows()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('select "foo" LIMIT 0')->then(function (QueryResult $command) {
             $this->assertCount(0, $command->resultRows);
@@ -264,13 +252,12 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSelectStaticTextTwoColumns()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('select "foo","bar"')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
@@ -281,13 +268,12 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSelectStaticTextTwoColumnsWithOneEmptyColumn()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('select "foo",""')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
@@ -298,13 +284,12 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSelectStaticTextTwoColumnsWithBothEmpty()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('select \'\' as `first`, \'\' as `second`')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
@@ -317,13 +302,12 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSelectStaticTextTwoColumnsWithSameNameOverwritesValue()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('select "foo" as `col`,"bar" as `col`')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
@@ -337,13 +321,12 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSelectCharsetDefaultsToUtf8()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('SELECT @@character_set_client')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
@@ -352,13 +335,12 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSelectWithExplcitCharsetReturnsCharset()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString() . '?charset=latin1';
         $connection = $factory->createLazyConnection($uri);
@@ -370,13 +352,12 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSimpleSelect()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         // re-create test "book" table
         $connection->query('DROP TABLE IF EXISTS book');
@@ -389,7 +370,7 @@ class ResultQueryTest extends BaseTestCase
         });
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     /**
@@ -397,8 +378,7 @@ class ResultQueryTest extends BaseTestCase
      */
     public function testSimpleSelectFromLazyConnectionWithoutDatabaseNameReturnsSameData()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString(array('dbname' => ''));
         $connection = $factory->createLazyConnection($uri);
@@ -408,13 +388,12 @@ class ResultQueryTest extends BaseTestCase
         })->done();
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testInvalidSelectShouldFail()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $options = $this->getConnectionOptions();
         $db = $options['dbname'];
@@ -427,13 +406,12 @@ class ResultQueryTest extends BaseTestCase
         );
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testInvalidMultiStatementsShouldFailToPreventSqlInjections()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $connection->query('select 1;select 2;')->then(
             $this->expectCallableNever(),
@@ -443,36 +421,34 @@ class ResultQueryTest extends BaseTestCase
         );
 
         $connection->quit();
-        $loop->run();
+        Loop::run();
     }
 
     public function testSelectAfterDelay()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
-        $loop->addTimer(0.1, function () use ($connection) {
+        Loop::addTimer(0.1, function () use ($connection) {
             $connection->query('select 1+1')->then(function (QueryResult $command) {
                 $this->assertEquals([['1+1' => 2]], $command->resultRows);
             });
             $connection->quit();
         });
 
-        $timeout = $loop->addTimer(1, function () use ($loop) {
-            $loop->stop();
+        $timeout = Loop::addTimer(1, function () {
+            Loop::stop();
             $this->fail('Test timeout');
         });
-        $connection->on('close', function () use ($loop, $timeout) {
-            $loop->cancelTimer($timeout);
+        $connection->on('close', function () use ($timeout) {
+            Loop::cancelTimer($timeout);
         });
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testQueryStreamStaticEmptyEmitsSingleRow()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $stream = $connection->queryStream('SELECT 1');
         $stream->on('data', $this->expectCallableOnceWith(array('1' => '1')));
@@ -480,14 +456,12 @@ class ResultQueryTest extends BaseTestCase
         $stream->on('close', $this->expectCallableOnce());
 
         $connection->quit();
-
-        $loop->run();
+        Loop::run();
     }
 
     public function testQueryStreamBoundVariableEmitsSingleRow()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $stream = $connection->queryStream('SELECT ? as value', array('test'));
         $stream->on('data', $this->expectCallableOnceWith(array('value' => 'test')));
@@ -495,14 +469,12 @@ class ResultQueryTest extends BaseTestCase
         $stream->on('close', $this->expectCallableOnce());
 
         $connection->quit();
-
-        $loop->run();
+        Loop::run();
     }
 
     public function testQueryStreamZeroRowsEmitsEndWithoutData()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $stream = $connection->queryStream('SELECT 1 LIMIT 0');
         $stream->on('data', $this->expectCallableNever());
@@ -510,14 +482,12 @@ class ResultQueryTest extends BaseTestCase
         $stream->on('close', $this->expectCallableOnce());
 
         $connection->quit();
-
-        $loop->run();
+        Loop::run();
     }
 
     public function testQueryStreamInvalidStatementEmitsError()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $stream = $connection->queryStream('SELECT');
         $stream->on('data', $this->expectCallableNever());
@@ -526,14 +496,12 @@ class ResultQueryTest extends BaseTestCase
         $stream->on('close', $this->expectCallableOnce());
 
         $connection->quit();
-
-        $loop->run();
+        Loop::run();
     }
 
     public function testQueryStreamDropStatementEmitsEndWithoutData()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $stream = $connection->queryStream('DROP TABLE IF exists helloworldtest1');
         $stream->on('data', $this->expectCallableNever());
@@ -541,14 +509,12 @@ class ResultQueryTest extends BaseTestCase
         $stream->on('close', $this->expectCallableOnce());
 
         $connection->quit();
-
-        $loop->run();
+        Loop::run();
     }
 
     public function testQueryStreamExplicitCloseEmitsCloseEventWithoutData()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $connection = $this->createConnection($loop);
+        $connection = $this->createConnection(Loop::get());
 
         $stream = $connection->queryStream('SELECT 1');
         $stream->on('data', $this->expectCallableNever());
@@ -557,14 +523,12 @@ class ResultQueryTest extends BaseTestCase
         $stream->close();
 
         $connection->quit();
-
-        $loop->run();
+        Loop::run();
     }
 
     public function testQueryStreamFromLazyConnectionEmitsSingleRow()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString();
         $connection = $factory->createLazyConnection($uri);
@@ -576,14 +540,12 @@ class ResultQueryTest extends BaseTestCase
         $stream->on('close', $this->expectCallableOnce());
 
         $connection->quit();
-
-        $loop->run();
+        Loop::run();
     }
 
     public function testQueryStreamFromLazyConnectionWillErrorWhenConnectionIsClosed()
     {
-        $loop = \React\EventLoop\Factory::create();
-        $factory = new Factory($loop);
+        $factory = new Factory();
 
         $uri = $this->getConnectionString();
         $connection = $factory->createLazyConnection($uri);
@@ -595,7 +557,5 @@ class ResultQueryTest extends BaseTestCase
         $stream->on('close', $this->expectCallableOnce());
 
         $connection->close();
-
-        $loop->run();
     }
 }


### PR DESCRIPTION
This changeset simplifies usage by supporting the new Socket API without nullable loop arguments.
Note that this doesn't affect the API of this package at all, but does use the improved API of the referenced Socket component. Existing code continues to work as is.

Together with #134, this means we can now fully rely on the [default loop](https://github.com/reactphp/event-loop#loop) and no longer need to skip any arguments with null values.

Builds on top of reactphp/socket#264 and reactphp/socket#263