### PR TITLE
Replace array() with [] and minor clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 This project aims to run on any platform and thus does not require any PHP
 extensions and supports running on legacy PHP 5.4 through current PHP 7+ and
 HHVM.
-It's *highly recommended to use PHP 7+* for this project.
+It's *highly recommended to use the latest supported PHP version* for this project.
 
 ## Tests
 
@@ -551,7 +551,7 @@ $ docker run -it --rm --net=host \
 To run the test suite, go to the project root and run:
 
 ```bash
-$ php vendor/bin/phpunit
+$ vendor/bin/phpunit
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -74,16 +74,16 @@ proxy servers etc.), you can explicitly pass a custom instance of the
 [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
 
 ```php
-$connector = new React\Socket\Connector(array(
+$connector = new React\Socket\Connector([
     'dns' => '127.0.0.1',
-    'tcp' => array(
+    'tcp' => [
         'bindto' => '192.168.10.1:0'
-    ),
-    'tls' => array(
+    ],
+    'tls' => [
         'verify_peer' => false,
         'verify_peer_name' => false
     )
-));
+]);
 
 $factory = new React\MySQL\Factory(null, $connector);
 ```
@@ -302,7 +302,7 @@ and sending your database queries.
 
 #### query()
 
-The `query(string $query, array $params = array()): PromiseInterface` method can be used to
+The `query(string $query, array $params = []): PromiseInterface` method can be used to
 perform an async query.
 
 This method returns a promise that will resolve with a `QueryResult` on
@@ -358,7 +358,7 @@ suited for exposing multiple possible results.
 
 #### queryStream()
 
-The `queryStream(string $sql, array $params = array()): ReadableStreamInterface` method can be used to
+The `queryStream(string $sql, array $params = []): ReadableStreamInterface` method can be used to
 perform an async query and stream the rows of the result set.
 
 This method returns a readable stream that will emit each row of the

--- a/examples/12-slow-stream.php
+++ b/examples/12-slow-stream.php
@@ -72,4 +72,6 @@ $factory->createConnection($uri)->then(function (ConnectionInterface $connection
     });
 
     $connection->quit();
-}, 'printf');
+}, function (Exception $e) {
+    echo 'Error: ' . $e->getMessage() . PHP_EOL;
+});

--- a/src/Commands/AuthenticateCommand.php
+++ b/src/Commands/AuthenticateCommand.php
@@ -33,7 +33,7 @@ class AuthenticateCommand extends AbstractCommand
      * @see self::$charsetNumber
      * @see \React\MySQL\Io\Query::$escapeChars
      */
-    private static $charsetMap = array(
+    private static $charsetMap = [
         'latin1' => 8,
         'latin2' => 9,
         'ascii' => 11,
@@ -42,7 +42,7 @@ class AuthenticateCommand extends AbstractCommand
         'latin7' => 41,
         'utf8mb4' => 45,
         'binary' => 63
-    );
+    ];
 
     /**
      * @param string $user

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -100,7 +100,7 @@ interface ConnectionInterface extends EventEmitterInterface
      * @param array  $params Parameters which should be bound to query
      * @return PromiseInterface Returns a Promise<QueryResult,Exception>
      */
-    public function query($sql, array $params = array());
+    public function query($sql, array $params = []);
 
     /**
      * Performs an async query and streams the rows of the result set.
@@ -161,7 +161,7 @@ interface ConnectionInterface extends EventEmitterInterface
      * @param array  $params Parameters which should be bound to query
      * @return ReadableStreamInterface
      */
-    public function queryStream($sql, $params = array());
+    public function queryStream($sql, $params = []);
 
     /**
      * Checks that the connection is alive.

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -42,16 +42,16 @@ class Factory
      * [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
      *
      * ```php
-     * $connector = new React\Socket\Connector(array(
+     * $connector = new React\Socket\Connector([
      *     'dns' => '127.0.0.1',
-     *     'tcp' => array(
+     *     'tcp' => [
      *         'bindto' => '192.168.10.1:0'
-     *     ),
-     *     'tls' => array(
+     *     ],
+     *     'tls' => [
      *         'verify_peer' => false,
      *         'verify_peer_name' => false
-     *     )
-     * ));
+     *     ]
+     * ]);
      *
      * $factory = new React\MySQL\Factory(null, $connector);
      * ```
@@ -62,7 +62,7 @@ class Factory
     public function __construct(LoopInterface $loop = null, ConnectorInterface $connector = null)
     {
         $this->loop = $loop ?: Loop::get();
-        $this->connector = $connector ?: new Connector(array(), $this->loop);
+        $this->connector = $connector ?: new Connector([], $this->loop);
     }
 
     /**

--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -57,7 +57,7 @@ class Connection extends EventEmitter implements ConnectionInterface
     /**
      * {@inheritdoc}
      */
-    public function query($sql, array $params = array())
+    public function query($sql, array $params = [])
     {
         $query = new Query($sql);
         if ($params) {
@@ -75,7 +75,7 @@ class Connection extends EventEmitter implements ConnectionInterface
         $deferred = new Deferred();
 
         // store all result set rows until result set end
-        $rows = array();
+        $rows = [];
         $command->on('result', function ($row) use (&$rows) {
             $rows[] = $row;
         });
@@ -85,7 +85,7 @@ class Connection extends EventEmitter implements ConnectionInterface
             $result->resultRows = $rows;
             $result->warningCount = $command->warningCount;
 
-            $rows = array();
+            $rows = [];
 
             $deferred->resolve($result);
         });
@@ -106,7 +106,7 @@ class Connection extends EventEmitter implements ConnectionInterface
         return $deferred->promise();
     }
 
-    public function queryStream($sql, $params = array())
+    public function queryStream($sql, $params = [])
     {
         $query = new Query($sql);
         if ($params) {
@@ -162,9 +162,9 @@ class Connection extends EventEmitter implements ConnectionInterface
         // reject all pending commands if connection is closed
         while (!$this->executor->isIdle()) {
             $command = $this->executor->dequeue();
-            $command->emit('error', array(
+            $command->emit('error', [
                 new \RuntimeException('Connection lost')
-            ));
+            ]);
         }
 
         $this->emit('close');

--- a/src/Io/LazyConnection.php
+++ b/src/Io/LazyConnection.php
@@ -33,7 +33,7 @@ class LazyConnection extends EventEmitter implements ConnectionInterface
 
     public function __construct(Factory $factory, $uri, LoopInterface $loop)
     {
-        $args = array();
+        $args = [];
         \parse_str(\parse_url($uri, \PHP_URL_QUERY), $args);
         if (isset($args['idle'])) {
             $this->idlePeriod = (float)$args['idle'];

--- a/src/Io/Parser.php
+++ b/src/Io/Parser.php
@@ -97,8 +97,8 @@ class Parser
 
     public function start()
     {
-        $this->stream->on('data', array($this, 'parse'));
-        $this->stream->on('close', array($this, 'onClose'));
+        $this->stream->on('data', [$this, 'parse']);
+        $this->stream->on('close', [$this, 'onClose']);
     }
 
     public function debug($message)
@@ -221,7 +221,7 @@ packet:
                 // Empty data packet during result set => row with only empty strings
                 $this->debug('Result set empty row data');
 
-                $row = array();
+                $row = [];
                 foreach ($this->resultFields as $field) {
                     $row[$field['name']] = '';
                 }
@@ -272,7 +272,7 @@ packet:
     {
         // $this->debug('row data: ' . json_encode($row));
         $command = $this->currCommand;
-        $command->emit('result', array($row));
+        $command->emit('result', [$row]);
     }
 
     private function onError(Exception $error)
@@ -283,7 +283,7 @@ packet:
             $command = $this->currCommand;
             $this->currCommand = null;
 
-            $command->emit('error', array($error));
+            $command->emit('error', [$error]);
         }
     }
 
@@ -322,9 +322,9 @@ packet:
             if ($command instanceof QuitCommand) {
                 $command->emit('success');
             } else {
-                $command->emit('error', array(
+                $command->emit('error', [
                     new \RuntimeException('Connection lost')
-                ));
+                ]);
             }
         }
     }

--- a/src/Io/Query.php
+++ b/src/Io/Query.php
@@ -22,7 +22,7 @@ class Query
      * @var array<string,string>
      * @see \React\MySQL\Commands\AuthenticateCommand::$charsetMap
      */
-    private $escapeChars = array(
+    private $escapeChars = [
             "\x00"   => "\\0",
             "\r"   => "\\r",
             "\n"   => "\\n",
@@ -34,7 +34,7 @@ class Query
             "\\"   => "\\\\",
             //"%"    => "\\%",
             //"_"    => "\\_",
-        );
+        ];
 
     public function __construct($sql)
     {
@@ -134,7 +134,7 @@ class Query
 
         return $sql;
         /*
-        $names    = array();
+        $names    = [];
         $inName   = false;
         $currName = '';
         $currIdx  = 0;
@@ -166,7 +166,7 @@ class Query
             $names[$currIdx] = $currName;
         }
 
-        $namedMarks = $unnamedMarks = array();
+        $namedMarks = $unnamedMarks = [];
         foreach ($this->params as $arg) {
             if (is_array($arg)) {
                 $namedMarks += $arg;

--- a/src/Io/QueryStream.php
+++ b/src/Io/QueryStream.php
@@ -33,7 +33,7 @@ class QueryStream extends EventEmitter implements ReadableStreamInterface
             }
             $this->started = true;
 
-            $this->emit('data', array($row));
+            $this->emit('data', [$row]);
         });
         $command->on('end', function () {
             $this->emit('end');
@@ -46,7 +46,7 @@ class QueryStream extends EventEmitter implements ReadableStreamInterface
             $this->close();
         });
         $command->on('error', function ($err) {
-            $this->emit('error', array($err));
+            $this->emit('error', [$err]);
             $this->close();
         });
     }

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -21,7 +21,7 @@ class BaseTestCase extends TestCase
         ] + ($debug ? ['debug' => true] : []);
     }
 
-    protected function getConnectionString($params = array())
+    protected function getConnectionString($params = [])
     {
         $parts = $params + $this->getConnectionOptions();
 
@@ -56,7 +56,7 @@ SQL;
 
     protected function expectCallableOnce()
     {
-        $mock = $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        $mock = $this->getMockBuilder('stdClass')->setMethods(['__invoke'])->getMock();
         $mock->expects($this->once())->method('__invoke');
 
         return $mock;
@@ -64,7 +64,7 @@ SQL;
 
     protected function expectCallableOnceWith($value)
     {
-        $mock = $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        $mock = $this->getMockBuilder('stdClass')->setMethods(['__invoke'])->getMock();
         $mock->expects($this->once())->method('__invoke')->with($value);
 
         return $mock;
@@ -72,7 +72,7 @@ SQL;
 
     protected function expectCallableNever()
     {
-        $mock = $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        $mock = $this->getMockBuilder('stdClass')->setMethods(['__invoke'])->getMock();
         $mock->expects($this->never())->method('__invoke');
 
         return $mock;

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -45,7 +45,7 @@ class FactoryTest extends BaseTestCase
 
     public function testConnectWillUseGivenUserInfoAsDatabaseCredentialsAfterUrldecoding()
     {
-        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(array('write'))->getMock();
+        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(['write'])->getMock();
         $connection->expects($this->once())->method('write')->with($this->stringContains("user!\0"));
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -57,12 +57,12 @@ class FactoryTest extends BaseTestCase
 
         $promise->then($this->expectCallableNever(), $this->expectCallableNever());
 
-        $connection->emit('data', array("\x33\0\0\0" . "\x0a" . "mysql\0" . str_repeat("\0", 44)));
+        $connection->emit('data', ["\x33\0\0\0" . "\x0a" . "mysql\0" . str_repeat("\0", 44)]);
     }
 
     public function testConnectWillUseGivenPathAsDatabaseNameAfterUrldecoding()
     {
-        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(array('write'))->getMock();
+        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(['write'])->getMock();
         $connection->expects($this->once())->method('write')->with($this->stringContains("test database\0"));
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -74,7 +74,7 @@ class FactoryTest extends BaseTestCase
 
         $promise->then($this->expectCallableNever(), $this->expectCallableNever());
 
-        $connection->emit('data', array("\x33\0\0\0" . "\x0a" . "mysql\0" . str_repeat("\0", 44)));
+        $connection->emit('data', ["\x33\0\0\0" . "\x0a" . "mysql\0" . str_repeat("\0", 44)]);
     }
 
     public function testConnectWithInvalidUriWillRejectWithoutConnecting()
@@ -107,7 +107,7 @@ class FactoryTest extends BaseTestCase
     {
         $factory = new Factory();
 
-        $uri = $this->getConnectionString(array('host' => 'example.invalid'));
+        $uri = $this->getConnectionString(['host' => 'example.invalid']);
         $promise = $factory->createConnection($uri);
 
         $promise->then(null, $this->expectCallableOnce());
@@ -119,7 +119,7 @@ class FactoryTest extends BaseTestCase
     {
         $factory = new Factory();
 
-        $uri = $this->getConnectionString(array('passwd' => 'invalidpass'));
+        $uri = $this->getConnectionString(['passwd' => 'invalidpass']);
         $promise = $factory->createConnection($uri);
 
         $promise->then(null, $this->expectCallableOnceWith(
@@ -138,14 +138,14 @@ class FactoryTest extends BaseTestCase
     {
         $factory = new Factory();
 
-        $socket = new SocketServer('127.0.0.1:0', array());
+        $socket = new SocketServer('127.0.0.1:0', []);
         $socket->on('connection', function ($connection) use ($socket) {
             $socket->close();
             $connection->close();
         });
 
         $parts = parse_url($socket->getAddress());
-        $uri = $this->getConnectionString(array('host' => $parts['host'], 'port' => $parts['port']));
+        $uri = $this->getConnectionString(['host' => $parts['host'], 'port' => $parts['port']]);
 
         $promise = $factory->createConnection($uri);
         $promise->then(null, $this->expectCallableOnce());
@@ -219,7 +219,7 @@ class FactoryTest extends BaseTestCase
 
         $factory = new Factory();
 
-        $uri = $this->getConnectionString(array('dbname' => ''));
+        $uri = $this->getConnectionString(['dbname' => '']);
         $factory->createConnection($uri)->then(function (ConnectionInterface $connection) {
             echo 'connected.';
             $connection->quit()->then(function () {
@@ -468,7 +468,7 @@ class FactoryTest extends BaseTestCase
     {
         $factory = new Factory();
 
-        $uri = $this->getConnectionString(array('passwd' => 'invalidpass'));
+        $uri = $this->getConnectionString(['passwd' => 'invalidpass']);
         $connection = $factory->createLazyConnection($uri);
 
         $connection->on('error', $this->expectCallableNever());

--- a/tests/Io/ConnectionTest.php
+++ b/tests/Io/ConnectionTest.php
@@ -10,7 +10,7 @@ class ConnectionTest extends BaseTestCase
     public function testQuitWillEnqueueOneCommand()
     {
         $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
-        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(array('enqueue'))->getMock();
+        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(['enqueue'])->getMock();
         $executor->expects($this->once())->method('enqueue')->willReturnArgument(0);
 
         $conn = new Connection($stream, $executor);
@@ -20,7 +20,7 @@ class ConnectionTest extends BaseTestCase
     public function testQueryAfterQuitRejectsImmediately()
     {
         $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
-        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(array('enqueue'))->getMock();
+        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(['enqueue'])->getMock();
         $executor->expects($this->once())->method('enqueue')->willReturnArgument(0);
 
         $conn = new Connection($stream, $executor);
@@ -34,7 +34,7 @@ class ConnectionTest extends BaseTestCase
     public function testQueryStreamAfterQuitThrows()
     {
         $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
-        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(array('enqueue'))->getMock();
+        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(['enqueue'])->getMock();
         $executor->expects($this->once())->method('enqueue')->willReturnArgument(0);
 
         $conn = new Connection($stream, $executor);
@@ -45,7 +45,7 @@ class ConnectionTest extends BaseTestCase
     public function testPingAfterQuitRejectsImmediately()
     {
         $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
-        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(array('enqueue'))->getMock();
+        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(['enqueue'])->getMock();
         $executor->expects($this->once())->method('enqueue')->willReturnArgument(0);
 
         $conn = new Connection($stream, $executor);
@@ -56,7 +56,7 @@ class ConnectionTest extends BaseTestCase
     public function testQuitAfterQuitRejectsImmediately()
     {
         $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
-        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(array('enqueue'))->getMock();
+        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(['enqueue'])->getMock();
         $executor->expects($this->once())->method('enqueue')->willReturnArgument(0);
 
         $conn = new Connection($stream, $executor);

--- a/tests/Io/LazyConnectionTest.php
+++ b/tests/Io/LazyConnectionTest.php
@@ -30,7 +30,7 @@ class LazyConnectionTest extends BaseTestCase
     }
     public function testPingWillNotCloseConnectionWhenUnderlyingConnectionCloses()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(array('ping'))->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(['ping'])->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
 
         $factory = $this->getMockBuilder('React\MySQL\Factory')->disableOriginalConstructor()->getMock();
@@ -47,7 +47,7 @@ class LazyConnectionTest extends BaseTestCase
 
     public function testPingWillCancelTimerWithoutClosingConnectionWhenUnderlyingConnectionCloses()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(array('ping'))->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(['ping'])->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
 
         $factory = $this->getMockBuilder('React\MySQL\Factory')->disableOriginalConstructor()->getMock();
@@ -68,7 +68,7 @@ class LazyConnectionTest extends BaseTestCase
 
     public function testPingWillNotForwardErrorFromUnderlyingConnection()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(array('ping'))->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(['ping'])->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
 
         $factory = $this->getMockBuilder('React\MySQL\Factory')->disableOriginalConstructor()->getMock();
@@ -86,7 +86,7 @@ class LazyConnectionTest extends BaseTestCase
 
     public function testPingFollowedByIdleTimerWillQuitUnderlyingConnection()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(array('ping', 'quit', 'close'))->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(['ping', 'quit', 'close'])->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
         $base->expects($this->once())->method('quit')->willReturn(\React\Promise\resolve());
         $base->expects($this->never())->method('close');
@@ -114,7 +114,7 @@ class LazyConnectionTest extends BaseTestCase
 
     public function testPingFollowedByIdleTimerWillCloseUnderlyingConnectionWhenQuitFails()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(array('ping', 'quit', 'close'))->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(['ping', 'quit', 'close'])->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
         $base->expects($this->once())->method('quit')->willReturn(\React\Promise\reject());
         $base->expects($this->once())->method('close');
@@ -142,7 +142,7 @@ class LazyConnectionTest extends BaseTestCase
 
     public function testPingAfterIdleTimerWillCloseUnderlyingConnectionBeforeCreatingSecondConnection()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(array('ping', 'quit', 'close'))->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(['ping', 'quit', 'close'])->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
         $base->expects($this->once())->method('quit')->willReturn(new Promise(function () { }));
         $base->expects($this->once())->method('close');
@@ -517,7 +517,7 @@ class LazyConnectionTest extends BaseTestCase
     {
         $error = new \RuntimeException();
 
-        $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(array('ping', 'close'))->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(['ping', 'close'])->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturnCallback(function () use ($base, $error) {
             $base->emit('close');
             return \React\Promise\reject($error);
@@ -703,7 +703,7 @@ class LazyConnectionTest extends BaseTestCase
 
     public function testCloseAfterPingHasResolvedWillCloseUnderlyingConnectionWithoutTryingToCancelConnection()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(array('ping', 'close'))->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(['ping', 'close'])->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
         $base->expects($this->once())->method('close')->willReturnCallback(function () use ($base) {
             $base->emit('close');

--- a/tests/Io/QueryStreamTest.php
+++ b/tests/Io/QueryStreamTest.php
@@ -12,9 +12,9 @@ class QueryStreamTest extends BaseTestCase
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
 
         $stream = new QueryStream($command, $connection);
-        $stream->on('data', $this->expectCallableOnceWith(array('key' => 'value')));
+        $stream->on('data', $this->expectCallableOnceWith(['key' => 'value']));
 
-        $command->emit('result', array(array('key' => 'value')));
+        $command->emit('result', [['key' => 'value']]);
     }
 
     public function testDataEventWillNotBeForwardedFromCommandResultAfterClosingStream()
@@ -26,7 +26,7 @@ class QueryStreamTest extends BaseTestCase
         $stream->on('data', $this->expectCallableNever());
         $stream->close();
 
-        $command->emit('result', array(array('key' => 'value')));
+        $command->emit('result', [['key' => 'value']]);
     }
 
     public function testEndEventWillBeForwardedFromCommandResult()
@@ -63,7 +63,7 @@ class QueryStreamTest extends BaseTestCase
         $stream->on('error', $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException')));
         $stream->on('close', $this->expectCallableOnce());
 
-        $command->emit('error', array(new RuntimeException()));
+        $command->emit('error', [new RuntimeException()]);
     }
 
     public function testPauseForwardsToConnectionAfterResultStarted()
@@ -73,7 +73,7 @@ class QueryStreamTest extends BaseTestCase
         $connection->expects($this->once())->method('pause');
 
         $stream = new QueryStream($command, $connection);
-        $command->emit('result', array(array()));
+        $command->emit('result', [[]]);
 
         $stream->pause();
     }
@@ -87,7 +87,7 @@ class QueryStreamTest extends BaseTestCase
         $stream = new QueryStream($command, $connection);
         $stream->pause();
 
-        $command->emit('result', array(array()));
+        $command->emit('result', [[]]);
     }
 
     public function testPauseDoesNotForwardToConnectionWhenResultIsNotStarted()
@@ -118,7 +118,7 @@ class QueryStreamTest extends BaseTestCase
         $connection->expects($this->once())->method('resume');
 
         $stream = new QueryStream($command, $connection);
-        $command->emit('result', array(array()));
+        $command->emit('result', [[]]);
 
         $stream->resume();
     }
@@ -166,7 +166,7 @@ class QueryStreamTest extends BaseTestCase
         $connection->expects($this->once())->method('resume');
 
         $stream = new QueryStream($command, $connection);
-        $command->emit('result', array(array()));
+        $command->emit('result', [[]]);
         $stream->pause();
         $stream->close();
     }

--- a/tests/Io/QueryTest.php
+++ b/tests/Io/QueryTest.php
@@ -18,11 +18,11 @@ class QueryTest extends TestCase
         $this->assertEquals("select * from test where id in (1,2) and name = 'test'", $sql);
         /*
         $query = new Query('select * from test where id = :id and name = :name');
-        $sql   = $query->params(array(':id' => 100, ':name' => 'test'))->getSql();
+        $sql   = $query->params([':id' => 100, ':name' => 'test'])->getSql();
         $this->assertEquals("select * from test where id = 100 and name = 'test'", $sql);
 
         $query = new Query('select * from test where id = :id and name = ?');
-        $sql   = $query->params('test', array(':id' => 100))->getSql();
+        $sql   = $query->params('test', [':id' => 100])->getSql();
         $this->assertEquals("select * from test where id = 100 and name = 'test'", $sql);
         */
     }

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -27,7 +27,7 @@ class ResultQueryTest extends BaseTestCase
 
     public function provideValuesThatWillBeReturnedAsIs()
     {
-        return array_map(function ($e) { return array($e); }, array(
+        return array_map(function ($e) { return [$e]; }, [
             'foo',
             'hello?',
             'FööBär',
@@ -36,17 +36,17 @@ class ResultQueryTest extends BaseTestCase
             "\0\1\2\3\4\5\6\7\8\xff",
             '',
             null
-        ));
+        ]);
     }
 
     public function provideValuesThatWillBeConvertedToString()
     {
-        return array(
-            array(1, '1'),
-            array(1.5, '1.5'),
-            array(true, '1'),
-            array(false, '0')
-        );
+        return [
+            [1, '1'],
+            [1.5, '1.5'],
+            [true, '1'],
+            [false, '0']
+        ];
     }
 
     /**
@@ -294,7 +294,7 @@ class ResultQueryTest extends BaseTestCase
         $connection->query('select \'\' as `first`, \'\' as `second`')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(2, $command->resultRows[0]);
-            $this->assertSame(array('', ''), array_values($command->resultRows[0]));
+            $this->assertSame(['', ''], array_values($command->resultRows[0]));
 
             $this->assertCount(2, $command->resultFields);
             $this->assertSame(Constants::FIELD_TYPE_VAR_STRING, $command->resultFields[0]['type']);
@@ -380,7 +380,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $factory = new Factory();
 
-        $uri = $this->getConnectionString(array('dbname' => ''));
+        $uri = $this->getConnectionString(['dbname' => '']);
         $connection = $factory->createLazyConnection($uri);
 
         $connection->query('select * from test.book')->then(function (QueryResult $command) {
@@ -451,7 +451,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = $this->createConnection(Loop::get());
 
         $stream = $connection->queryStream('SELECT 1');
-        $stream->on('data', $this->expectCallableOnceWith(array('1' => '1')));
+        $stream->on('data', $this->expectCallableOnceWith(['1' => '1']));
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('close', $this->expectCallableOnce());
 
@@ -463,8 +463,8 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $stream = $connection->queryStream('SELECT ? as value', array('test'));
-        $stream->on('data', $this->expectCallableOnceWith(array('value' => 'test')));
+        $stream = $connection->queryStream('SELECT ? as value', ['test']);
+        $stream->on('data', $this->expectCallableOnceWith(['value' => 'test']));
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('close', $this->expectCallableOnce());
 


### PR DESCRIPTION
I noticed that this project still uses the `array()` notation instead of `[]`. The `array()` notation was needed for PHP version < 5.4 which is not the case in this project.
I know it's not a necessary change so if there is any good reason to keep the old stuff let me know.