### PR TITLE
Support URI scheme to create connection

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -158,7 +158,11 @@ class Factory
      */
     public function createConnection($uri)
     {
-        $parts = parse_url('mysql://' . $uri);
+        if (strpos($uri, '://') === false) {
+            $uri = 'mysql://' . $uri;
+        }
+
+        $parts = parse_url($uri);
         if (!isset($parts['scheme'], $parts['host']) || $parts['scheme'] !== 'mysql') {
             return \React\Promise\reject(new \InvalidArgumentException('Invalid connect uri given'));
         }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -32,6 +32,29 @@ class FactoryTest extends BaseTestCase
         $factory->createConnection('127.0.0.1');
     }
 
+    public function testConnectWillUseGivenScheme()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $pending = $this->getMockBuilder('React\Promise\PromiseInterface')->getMock();
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('127.0.0.1:3306')->willReturn($pending);
+
+        $factory = new Factory($loop, $connector);
+        $factory->createConnection('mysql://127.0.0.1');
+    }
+
+    public function testConnectWillRejectWhenGivenInvalidScheme()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+
+        $factory = new Factory($loop, $connector);
+
+        $promise = $factory->createConnection('foo://127.0.0.1');
+
+        $promise->then(null, $this->expectCallableOnceWith($this->isInstanceOf('InvalidArgumentException')));
+    }
+
     public function testConnectWillUseGivenHostAndGivenPort()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();


### PR DESCRIPTION
With these changes it's possible to pass an URI scheme to your `createconnection()`. 
If no scheme is given it defaults to `mysql://`
If you pass an invalid URI scheme (anything other than `mysql://`) it will be rejected with an `InvalidArgumentException`