### PR TITLE
Provide limited support for `NO_BACKSLASH_ESCAPES` SQL mode

### DIFF
--- a/src/Io/Query.php
+++ b/src/Io/Query.php
@@ -19,18 +19,23 @@ class Query
      * Note that this mapping assumes an ASCII-compatible charset encoding such
      * as UTF-8, ISO 8859 and others.
      *
+     * Note that `'` will be escaped as `''` instead of `\'` to provide some
+     * limited support for the `NO_BACKSLASH_ESCAPES` SQL mode. This assumes all
+     * strings will always be enclosed in `'` instead of `"` which is guaranteed
+     * as long as this class is only used internally for the `query()` method.
+     *
      * @var array<string,string>
      * @see \React\MySQL\Commands\AuthenticateCommand::$charsetMap
      */
     private $escapeChars = [
-            "\x00"   => "\\0",
-            "\r"   => "\\r",
-            "\n"   => "\\n",
-            "\t"   => "\\t",
+            //"\x00"   => "\\0",
+            //"\r"   => "\\r",
+            //"\n"   => "\\n",
+            //"\t"   => "\\t",
             //"\b"   => "\\b",
             //"\x1a" => "\\Z",
-            "'"    => "\'",
-            '"'    => '\"',
+            "'"    => "''",
+            //'"'    => '\"',
             "\\"   => "\\\\",
             //"%"    => "\\%",
             //"_"    => "\\_",

--- a/tests/Io/QueryTest.php
+++ b/tests/Io/QueryTest.php
@@ -66,12 +66,9 @@ class QueryTest extends TestCase
     {
         $query = new Query('');
         $this->assertEquals('\\\\', $query->escape('\\'));
-        $this->assertEquals('\"', $query->escape('"'));
-        $this->assertEquals("\'", $query->escape("'"));
-        $this->assertEquals("\\n", $query->escape("\n"));
-        $this->assertEquals("\\r", $query->escape("\r"));
-        $this->assertEquals("foo\\0bar", $query->escape("foo" . chr(0) . "bar"));
+        $this->assertEquals("''", $query->escape("'"));
+        $this->assertEquals("foo\0bar", $query->escape("foo" . chr(0) . "bar"));
         $this->assertEquals("n%3A", $query->escape("n%3A"));
-        //$this->assertEquals('§ä¨ì¥H¤U¤º®e\\\\§ä¨ì¥H¤U¤º®e', $query->escape('§ä¨ì¥H¤U¤º®e\\§ä¨ì¥H¤U¤º®e'));
+        $this->assertEquals('§ä¨ì¥H¤U¤º®e\\\\§ä¨ì¥H¤U¤º®e', $query->escape('§ä¨ì¥H¤U¤º®e\\§ä¨ì¥H¤U¤º®e'));
     }
 }


### PR DESCRIPTION
This changeset provides limited support for the `NO_BACKSLASH_ESCAPES` SQL mode. From my experience I would say this is rarely used in practice and using the `NO_BACKSLASH_ESCAPES` SQL mode is usually not recommended. Accordingly, this changeset has no effect on most installations.

When the `NO_BACKSLASH_ESCAPES` SQL mode is used, backslash escapes such as `\'` will no longer be interpreted as a single character but instead as the two literals. This means we have to take special care when trying to escape string values that contain a `'` character to avoid possible SQL injections. Instead, we can replace each `'` with `''` which ends up being interpreted as a single `'` irrespective of whether the `NO_BACKSLASH_ESCAPES` SQL mode is used. Accordingly, I've removed most unneeded escape sequences which might introduce unneeded backslashes otherwise. The updated test suite cases confirm this works across both modes.

In other words, this new implementation is now somewhat closer to what MySQL implements for its `mysql_real_escape_string_quote()` function. The only known limitation is that passing a single backslash character will end up as two backslash characters. This can not be avoided with the current design, as we would have to otherwise know the actual SQL mode used (which depends on server and client side settings) or resort to work-arounds such as using `UNHEX()` and `CONCAT()`. I believe the changeset provides a significant improvement over the previous situation as-is and beyond this, it's probably best to look into full prepared statement support in a future version.

Link dump:
* https://github.com/mysqljs/mysql/issues/1828 / https://github.com/mysqljs/mysql#escaping-query-values (not supported at all in many common libraries)
* https://github.com/mysql-net/MySqlConnector/issues/701
* https://github.com/apache/incubator-doris/issues/381
* https://dev.mysql.com/doc/refman/8.0/en/string-literals.html
* https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_no_backslash_escapes
* https://dev.mysql.com/doc/c-api/8.0/en/mysql-real-escape-string-quote.html
* https://github.com/twitter-forks/mysql/blob/865aae5f23e2091e1316ca0e6c6651d57f786c76/mysys/charset.c#L889
* https://github.com/twitter-forks/mysql/blob/865aae5f23e2091e1316ca0e6c6651d57f786c76/mysys/charset.c#L749
* https://stackoverflow.com/questions/5741187/sql-injection-that-gets-around-mysql-real-escape-string
* https://stackoverflow.com/questions/45419007/what-are-repercussions-of-enabling-no-backslash-escapes-in-mariadb

Together with #135, this resolves #131