### PR TITLE
Improve error reporting, include MySQL URI and socket error codes in all connection errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ This example runs a simple `SELECT` query and dumps all the records from a `book
 
 ```php
 $factory = new React\MySQL\Factory();
-
-$uri = 'test:test@localhost/test';
-$connection = $factory->createLazyConnection($uri);
+$connection = $factory->createLazyConnection('user:pass@localhost/bookstore');
 
 $connection->query('SELECT * FROM book')->then(
     function (QueryResult $command) {

--- a/examples/01-query.php
+++ b/examples/01-query.php
@@ -1,18 +1,17 @@
 <?php
 
+// $ php examples/01-query.php
+// $ MYSQL_URI=test:test@localhost/test php examples/01-query.php "SELECT * FROM book"
+
 use React\MySQL\Factory;
 use React\MySQL\QueryResult;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $factory = new Factory();
+$connection = $factory->createLazyConnection(getenv('MYSQL_URI') ?: 'test:test@localhost/test');
 
-$uri = 'test:test@localhost/test';
 $query = isset($argv[1]) ? $argv[1] : 'select * from book';
-
-//create a lazy mysql connection for executing query
-$connection = $factory->createLazyConnection($uri);
-
 $connection->query($query)->then(function (QueryResult $command) {
     if (isset($command->resultRows)) {
         // this is a response to a SELECT etc. with some rows (0+)

--- a/examples/02-query-stream.php
+++ b/examples/02-query-stream.php
@@ -1,19 +1,16 @@
 <?php
 
 // $ php examples/02-query-stream.php "SHOW VARIABLES"
+// $ MYSQL_URI=test:test@localhost/test php examples/02-query-stream.php "SELECT * FROM book"
 
 use React\MySQL\Factory;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $factory = new Factory();
+$connection = $factory->createLazyConnection(getenv('MYSQL_URI') ?: 'test:test@localhost/test');
 
-$uri = 'test:test@localhost/test';
 $query = isset($argv[1]) ? $argv[1] : 'select * from book';
-
-//create a lazy mysql connection for executing query
-$connection = $factory->createLazyConnection($uri);
-
 $stream = $connection->queryStream($query);
 
 $stream->on('data', function ($row) {

--- a/examples/11-interactive.php
+++ b/examples/11-interactive.php
@@ -1,5 +1,8 @@
 <?php
 
+// $ php examples/11-interactive.php
+// $ MYSQL_URI=test:test@localhost/test php examples/11-interactive.php
+
 use React\MySQL\ConnectionInterface;
 use React\MySQL\QueryResult;
 use React\MySQL\Factory;
@@ -8,8 +11,7 @@ use React\Stream\ReadableResourceStream;
 require __DIR__ . '/../vendor/autoload.php';
 
 $factory = new Factory();
-
-$uri = 'test:test@localhost/test';
+$uri = getenv('MYSQL_URI') ?: 'test:test@localhost/test';
 
 // open a STDIN stream to read keyboard input (not supported on Windows)
 $stdin = new ReadableResourceStream(STDIN);

--- a/examples/12-slow-stream.php
+++ b/examples/12-slow-stream.php
@@ -1,6 +1,7 @@
 <?php
 
 // $ php examples/12-slow-stream.php "SHOW VARIABLES"
+// $ MYSQL_URI=test:test@localhost/test php examples/12-slow-stream.php "SELECT * FROM book"
 
 use React\EventLoop\Loop;
 use React\MySQL\ConnectionInterface;
@@ -9,8 +10,8 @@ use React\MySQL\Factory;
 require __DIR__ . '/../vendor/autoload.php';
 
 $factory = new Factory();
+$uri = getenv('MYSQL_URI') ?: 'test:test@localhost/test';
 
-$uri = 'test:test@localhost/test';
 $query = isset($argv[1]) ? $argv[1] : 'select * from book';
 
 //create a mysql connection for executing query

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -163,8 +163,9 @@ class Factory
         }
 
         $parts = parse_url($uri);
+        $uri = preg_replace('#:[^:/]*@#', ':***@', $uri);
         if (!isset($parts['scheme'], $parts['host']) || $parts['scheme'] !== 'mysql') {
-            return \React\Promise\reject(new \InvalidArgumentException('Invalid connect uri given'));
+            return \React\Promise\reject(new \InvalidArgumentException('Invalid MySQL URI given'));
         }
 
         $args = [];
@@ -187,9 +188,11 @@ class Factory
             $parts['host'] . ':' . (isset($parts['port']) ? $parts['port'] : 3306)
         );
 
-        $deferred = new Deferred(function ($_, $reject) use ($connecting) {
+        $deferred = new Deferred(function ($_, $reject) use ($connecting, $uri) {
             // connection cancelled, start with rejecting attempt, then clean up
-            $reject(new \RuntimeException('Connection to database server cancelled'));
+            $reject(new \RuntimeException(
+                'Connection to ' . $uri . ' cancelled'
+            ));
 
             // either close successful connection or cancel pending connection attempt
             $connecting->then(function (SocketConnectionInterface $connection) {
@@ -198,7 +201,7 @@ class Factory
             $connecting->cancel();
         });
 
-        $connecting->then(function (SocketConnectionInterface $stream) use ($authCommand, $deferred) {
+        $connecting->then(function (SocketConnectionInterface $stream) use ($authCommand, $deferred, $uri) {
             $executor = new Executor();
             $parser = new Parser($stream, $executor);
 
@@ -209,12 +212,20 @@ class Factory
             $command->on('success', function () use ($deferred, $connection) {
                 $deferred->resolve($connection);
             });
-            $command->on('error', function ($error) use ($deferred, $stream) {
-                $deferred->reject($error);
+            $command->on('error', function (\Exception $error) use ($deferred, $stream, $uri) {
+                $deferred->reject(new \RuntimeException(
+                    'Connection to ' . $uri . ' failed during authentication: ' . $error->getMessage(),
+                    $error->getCode(),
+                    $error
+                ));
                 $stream->close();
             });
-        }, function ($error) use ($deferred) {
-            $deferred->reject(new \RuntimeException('Unable to connect to database server', 0, $error));
+        }, function (\Exception $error) use ($deferred, $uri) {
+            $deferred->reject(new \RuntimeException(
+                'Connection to ' . $uri . ' failed: ' . $error->getMessage(),
+                $error->getCode(),
+                $error
+            ));
         });
 
         // use timeout from explicit ?timeout=x parameter or default to PHP's default_socket_timeout (60)
@@ -223,10 +234,10 @@ class Factory
             return $deferred->promise();
         }
 
-        return \React\Promise\Timer\timeout($deferred->promise(), $timeout, $this->loop)->then(null, function ($e) {
+        return \React\Promise\Timer\timeout($deferred->promise(), $timeout, $this->loop)->then(null, function ($e) use ($uri) {
             if ($e instanceof TimeoutException) {
                 throw new \RuntimeException(
-                    'Connection to database server timed out after ' . $e->getTimeout() . ' seconds'
+                    'Connection to ' . $uri . ' timed out after ' . $e->getTimeout() . ' seconds'
                 );
             }
             throw $e;

--- a/src/Io/Parser.php
+++ b/src/Io/Parser.php
@@ -307,7 +307,7 @@ packet:
         if ($command instanceof QueryCommand) {
             $command->affectedRows = $this->affectedRows;
             $command->insertId     = $this->insertId;
-            $command->warningCount    = $this->warningCount;
+            $command->warningCount = $this->warningCount;
             $command->message      = $this->message;
         }
         $command->emit('success');
@@ -322,9 +322,10 @@ packet:
             if ($command instanceof QuitCommand) {
                 $command->emit('success');
             } else {
-                $command->emit('error', [
-                    new \RuntimeException('Connection lost')
-                ]);
+                $command->emit('error', [new \RuntimeException(
+                    'Connection closing (ECONNABORTED)',
+                    \defined('SOCKET_ECONNABORTED') ? \SOCKET_ECONNABORTED : 103
+                )]);
             }
         }
     }


### PR DESCRIPTION
This changeset improves error reporting to include the MySQL URI and socket error codes in all connection errors:

```diff
- Error: Unable to connect to database server
- Error: Access denied for user 'test'@'::1' (using password: YES)
+ Error: Connection to mysql://test:***@localhost/test failed: Connection to localhost:3306 failed: Last error for IPv4: Connection to tcp://127.0.0.1:3306?hostname=localhost failed: Connection refused. Previous error for IPv6: Connection to tcp://[::1]:3306?hostname=localhost failed: Connection refused
+ Error: Connection to mysql://test:***@localhost/test failed during authentication: Access denied for user 'test'@'::1' (using password: YES) (EACCES)
```

Builds on top of #138, https://github.com/clue/reactphp-redis/pull/116, https://github.com/clue/reactphp-http-proxy/pull/17 and others