### PR TITLE
Run tests on PHPUnit 9 and PHP 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.0
           - 7.4
           - 7.3
           - 7.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
       - run: composer install
       - run: docker run -d --name mysql --net=host -e MYSQL_RANDOM_ROOT_PASSWORD=yes -e MYSQL_DATABASE=test -e MYSQL_USER=test -e MYSQL_PASSWORD=test mysql:5
       - run: bash tests/wait-for-mysql.sh
-      - run: MYSQL_USER=test MYSQL_PASSWORD=test vendor/bin/phpunit
+      - run: MYSQL_USER=test MYSQL_PASSWORD=test vendor/bin/phpunit --coverage-text
+        if: ${{ matrix.php >= 7.3 }}
+      - run: MYSQL_USER=test MYSQL_PASSWORD=test vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
+        if: ${{ matrix.php < 7.3 }}
 
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)

--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ $ composer require react/mysql:^0.5.5
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.4 through current PHP 7+ and
+extensions and supports running on legacy PHP 5.4 through current PHP 8+ and
 HHVM.
 It's *highly recommended to use the latest supported PHP version* for this project.
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "clue/block-react": "^1.2",
-        "phpunit/phpunit": "^9.3 || ^6.0 || ^5.0 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "clue/block-react": "^1.2",
-        "phpunit/phpunit": "^7.0 || ^6.0 || ^5.0 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^6.0 || ^5.0 || ^4.8.35"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,28 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          backupGlobals="false"
          backupStaticAttributes="false"
          bootstrap="vendor/autoload.php"
-         cacheResult="false"
+         colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
-         colors="true"
          processIsolation="false"
          stopOnFailure="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd">
     <testsuites>
         <testsuite name="React.MySQL Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <include>
+    <filter>
+        <whitelist>
             <directory>./src/</directory>
-        </include>
-    </coverage>
+        </whitelist>
+    </filter>
     <php>
         <env name="DB_HOST" value="127.0.0.1"/>
         <env name="DB_PORT" value="3306"/>

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -77,4 +77,21 @@ SQL;
 
         return $mock;
     }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5.2+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 5.1
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
+    }
 }

--- a/tests/Io/BufferTest.php
+++ b/tests/Io/BufferTest.php
@@ -2,10 +2,10 @@
 
 namespace React\Tests\MySQL\Io;
 
-use PHPUnit\Framework\TestCase;
 use React\MySQL\Io\Buffer;
+use React\Tests\MySQL\BaseTestCase;
 
-class BufferTest extends TestCase
+class BufferTest extends BaseTestCase
 {
     public function testAppendAndReadBinary()
     {
@@ -16,15 +16,13 @@ class BufferTest extends TestCase
         $this->assertSame('hello', $buffer->read(5));
     }
 
-    /**
-     * @expectedException LogicException
-     */
     public function testReadBeyondLimitThrows()
     {
         $buffer = new Buffer();
 
         $buffer->append('hi');
 
+        $this->setExpectedException('LogicException');
         $buffer->read(3);
     }
 
@@ -38,27 +36,23 @@ class BufferTest extends TestCase
         $this->assertSame('i', $buffer->read(1));
     }
 
-    /**
-     * @expectedException LogicException
-     */
     public function testSkipZeroThrows()
     {
         $buffer = new Buffer();
 
         $buffer->append('hi');
 
+        $this->setExpectedException('LogicException');
         $buffer->skip(0);
     }
 
-    /**
-     * @expectedException LogicException
-     */
     public function testSkipBeyondLimitThrows()
     {
         $buffer = new Buffer();
 
         $buffer->append('hi');
 
+        $this->setExpectedException('LogicException');
         $buffer->skip(3);
     }
 
@@ -203,14 +197,12 @@ class BufferTest extends TestCase
         $this->assertEquals('world', $buffer->readStringNull());
     }
 
-    /**
-     * @expectedException LogicException
-     */
     public function testParseStringNullCharacterThrowsIfNullNotFound()
     {
         $buffer = new Buffer();
         $buffer->append("hello");
 
+        $this->setExpectedException('LogicException');
         $buffer->readStringNull();
     }
 }

--- a/tests/Io/LazyConnectionTest.php
+++ b/tests/Io/LazyConnectionTest.php
@@ -795,9 +795,6 @@ class LazyConnectionTest extends BaseTestCase
         $ret->then($this->expectCallableNever(), $this->expectCallableOnce());
     }
 
-    /**
-     * @expectedException React\MySQL\Exception
-     */
     public function testQueryStreamThrowsAfterConnectionIsClosed()
     {
         $factory = $this->getMockBuilder('React\MySQL\Factory')->disableOriginalConstructor()->getMock();
@@ -806,6 +803,8 @@ class LazyConnectionTest extends BaseTestCase
         $connection = new LazyConnection($factory, '', $loop);
 
         $connection->close();
+
+        $this->setExpectedException('React\MySQL\Exception');
         $connection->queryStream('SELECT 1');
     }
 

--- a/tests/NoResultQueryTest.php
+++ b/tests/NoResultQueryTest.php
@@ -7,7 +7,10 @@ use React\MySQL\QueryResult;
 
 class NoResultQueryTest extends BaseTestCase
 {
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpDataTable()
     {
         $connection = $this->createConnection(Loop::get());
 


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.

For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.
This pull request builds on top of #132.

It's also possible to run this code with PHP 8 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --net=host --workdir=/data php:8.0.0 php vendor/bin/phpunit
PHPUnit 9.5.8 by Sebastian Bergmann and contributors.

...............................................................  63 / 201 ( 31%)
............................................................... 126 / 201 ( 62%)
....................................I.......................... 189 / 201 ( 94%)
............                                                    201 / 201 (100%)

Time: 00:00.480, Memory: 42.43 MB

OK, but incomplete, skipped, or risky tests!
Tests: 201, Assertions: 527, Incomplete: 1.
```