### PR TITLE
Add `.gitattributes` to exclude dev files from export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.gitattributes export-ignore
+/.github/ export-ignore
+/.gitignore export-ignore
+/examples/ export-ignore
+/phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
+/tests/ export-ignore


### PR DESCRIPTION
Builds on top of #142.