### PR TITLE
Support PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.1
           - 8.0
           - 7.4
           - 7.3

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "react/event-loop": "^1.2",
         "react/promise": "^2.7",
         "react/promise-stream": "^1.1",
-        "react/promise-timer": "^1.5",
+        "react/promise-timer": "^1.8",
         "react/socket": "^1.9"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,17 +2,11 @@
 
 <!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         backupGlobals="false"
-         backupStaticAttributes="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          cacheResult="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          colors="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+         convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="React.MySQL Test Suite">
             <directory>./tests/</directory>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -2,16 +2,9 @@
 
 <!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         backupGlobals="false"
-         backupStaticAttributes="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd">
+         colors="true">
     <testsuites>
         <testsuite name="React.MySQL Test Suite">
             <directory>./tests/</directory>

--- a/src/Io/LazyConnection.php
+++ b/src/Io/LazyConnection.php
@@ -34,7 +34,7 @@ class LazyConnection extends EventEmitter implements ConnectionInterface
     public function __construct(Factory $factory, $uri, LoopInterface $loop)
     {
         $args = [];
-        \parse_str(\parse_url($uri, \PHP_URL_QUERY), $args);
+        \parse_str((string) \parse_url($uri, \PHP_URL_QUERY), $args);
         if (isset($args['idle'])) {
             $this->idlePeriod = (float)$args['idle'];
         }

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -68,7 +68,7 @@ class ResultQueryTest extends BaseTestCase
      */
     public function testSelectStaticValueWillBeReturnedAsIsWithNoBackslashEscapesSqlMode($value)
     {
-        if (strpos($value, '\\') !== false) {
+        if ($value !== null && strpos($value, '\\') !== false) {
             // TODO: strings such as '%\\' work as-is when string contains percent?!
             $this->markTestIncomplete('Escaping backslash not supported when using NO_BACKSLASH_ESCAPES SQL mode');
         }


### PR DESCRIPTION
This changeset adds support for PHP 8.1.

~~I'm marking this as WIP because it currently reports a deprecation notice that needs to be addressed upstream first (https://github.com/reactphp/promise-timer/pull/50). I'll update this PR once this version is released.~~

Builds on top of #142
Resolves / closes #149