### PR TITLE
Forward compatibility with upcoming Promise v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: composer install
       - run: docker run -d --name mysql --net=host -e MYSQL_RANDOM_ROOT_PASSWORD=yes -e MYSQL_DATABASE=test -e MYSQL_USER=test -e MYSQL_PASSWORD=test mysql:5
       - run: bash tests/wait-for-mysql.sh
@@ -39,6 +41,7 @@ jobs:
     name: PHPUnit (HHVM)
     runs-on: ubuntu-18.04
     continue-on-error: true
+    if: false # temporarily skipped until https://github.com/azjezz/setup-hhvm/issues/3 is addressed
     steps:
       - uses: actions/checkout@v2
       - uses: azjezz/setup-hhvm@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,6 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: composer install
       - run: docker run -d --name mysql --net=host -e MYSQL_RANDOM_ROOT_PASSWORD=yes -e MYSQL_DATABASE=test -e MYSQL_USER=test -e MYSQL_PASSWORD=test mysql:5
       - run: bash tests/wait-for-mysql.sh
@@ -41,7 +39,6 @@ jobs:
     name: PHPUnit (HHVM)
     runs-on: ubuntu-18.04
     continue-on-error: true
-    if: false # temporarily skipped until https://github.com/azjezz/setup-hhvm/issues/3 is addressed
     steps:
       - uses: actions/checkout@v2
       - uses: azjezz/setup-hhvm@v1

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
         "php": ">=5.4.0",
         "evenement/evenement": "^3.0 || ^2.1 || ^1.1",
         "react/event-loop": "^1.2",
-        "react/promise": "^3@dev || ^2.7",
+        "react/promise": "^3 || ^2.7",
         "react/promise-stream": "^1.4",
         "react/promise-timer": "^1.9",
-        "react/socket": "dev-promise-3 as 1.12.0"
+        "react/socket": "^1.12"
     },
     "require-dev": {
         "clue/block-react": "^1.5",
@@ -25,11 +25,5 @@
         "psr-4": {
             "React\\Tests\\MySQL\\": "tests"
         }
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/WyriHaximus-labs/socket"
-        }
-    ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,13 @@
         "php": ">=5.4.0",
         "evenement/evenement": "^3.0 || ^2.1 || ^1.1",
         "react/event-loop": "^1.2",
-        "react/promise": "^2.7",
-        "react/promise-stream": "^1.1",
-        "react/promise-timer": "^1.8",
-        "react/socket": "^1.9"
+        "react/promise": "^3@dev || ^2.7",
+        "react/promise-stream": "^1.4",
+        "react/promise-timer": "^1.9",
+        "react/socket": "dev-promise-3 as 1.12.0"
     },
     "require-dev": {
-        "clue/block-react": "^1.2",
+        "clue/block-react": "^1.5",
         "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     },
     "autoload": {
@@ -25,5 +25,11 @@
         "psr-4": {
             "React\\Tests\\MySQL\\": "tests"
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/WyriHaximus-labs/socket"
+        }
+    ]
 }

--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -128,7 +128,7 @@ class Connection extends EventEmitter implements ConnectionInterface
                     $reject($reason);
                 })
                 ->on('success', function () use ($resolve) {
-                    $resolve();
+                    $resolve(null);
                 });
         });
     }
@@ -144,7 +144,7 @@ class Connection extends EventEmitter implements ConnectionInterface
                     $this->state = self::STATE_CLOSED;
                     $this->emit('end', [$this]);
                     $this->emit('close', [$this]);
-                    $resolve();
+                    $resolve(null);
                 });
             $this->state = self::STATE_CLOSEING;
         });

--- a/src/Io/LazyConnection.php
+++ b/src/Io/LazyConnection.php
@@ -181,7 +181,7 @@ class LazyConnection extends EventEmitter implements ConnectionInterface
         // not already connecting => no need to connect, simply close virtual connection
         if ($this->connecting === null) {
             $this->close();
-            return \React\Promise\resolve();
+            return \React\Promise\resolve(null);
         }
 
         return $this->connecting()->then(function (ConnectionInterface $connection) {

--- a/tests/Io/LazyConnectionTest.php
+++ b/tests/Io/LazyConnectionTest.php
@@ -31,7 +31,7 @@ class LazyConnectionTest extends BaseTestCase
     public function testPingWillNotCloseConnectionWhenUnderlyingConnectionCloses()
     {
         $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(['ping'])->disableOriginalConstructor()->getMock();
-        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
+        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
 
         $factory = $this->getMockBuilder('React\MySQL\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
@@ -48,7 +48,7 @@ class LazyConnectionTest extends BaseTestCase
     public function testPingWillCancelTimerWithoutClosingConnectionWhenUnderlyingConnectionCloses()
     {
         $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(['ping'])->disableOriginalConstructor()->getMock();
-        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
+        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
 
         $factory = $this->getMockBuilder('React\MySQL\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
@@ -69,7 +69,7 @@ class LazyConnectionTest extends BaseTestCase
     public function testPingWillNotForwardErrorFromUnderlyingConnection()
     {
         $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(['ping'])->disableOriginalConstructor()->getMock();
-        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
+        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
 
         $factory = $this->getMockBuilder('React\MySQL\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
@@ -87,8 +87,8 @@ class LazyConnectionTest extends BaseTestCase
     public function testPingFollowedByIdleTimerWillQuitUnderlyingConnection()
     {
         $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(['ping', 'quit', 'close'])->disableOriginalConstructor()->getMock();
-        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
-        $base->expects($this->once())->method('quit')->willReturn(\React\Promise\resolve());
+        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
+        $base->expects($this->once())->method('quit')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->never())->method('close');
 
         $factory = $this->getMockBuilder('React\MySQL\Factory')->disableOriginalConstructor()->getMock();
@@ -115,8 +115,8 @@ class LazyConnectionTest extends BaseTestCase
     public function testPingFollowedByIdleTimerWillCloseUnderlyingConnectionWhenQuitFails()
     {
         $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(['ping', 'quit', 'close'])->disableOriginalConstructor()->getMock();
-        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
-        $base->expects($this->once())->method('quit')->willReturn(\React\Promise\reject());
+        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
+        $base->expects($this->once())->method('quit')->willReturn(\React\Promise\reject(new \RuntimeException()));
         $base->expects($this->once())->method('close');
 
         $factory = $this->getMockBuilder('React\MySQL\Factory')->disableOriginalConstructor()->getMock();
@@ -143,7 +143,7 @@ class LazyConnectionTest extends BaseTestCase
     public function testPingAfterIdleTimerWillCloseUnderlyingConnectionBeforeCreatingSecondConnection()
     {
         $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(['ping', 'quit', 'close'])->disableOriginalConstructor()->getMock();
-        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
+        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('quit')->willReturn(new Promise(function () { }));
         $base->expects($this->once())->method('close');
 
@@ -289,7 +289,7 @@ class LazyConnectionTest extends BaseTestCase
     public function testQueryAfterPingWillCancelTimerAgainWhenPingFromUnderlyingConnectionResolved()
     {
         $base = $this->getMockBuilder('React\MySQL\ConnectionInterface')->getMock();
-        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
+        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('query')->with('SELECT 1')->willReturn(new Promise(function () { }));
 
         $factory = $this->getMockBuilder('React\MySQL\Factory')->disableOriginalConstructor()->getMock();
@@ -480,7 +480,7 @@ class LazyConnectionTest extends BaseTestCase
     public function testPingWillResolveAndStartTimerWhenPingFromUnderlyingConnectionResolves()
     {
         $base = $this->getMockBuilder('React\MySQL\ConnectionInterface')->getMock();
-        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
+        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
 
         $factory = $this->getMockBuilder('React\MySQL\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
@@ -570,7 +570,7 @@ class LazyConnectionTest extends BaseTestCase
     public function testQuitAfterPingWillQuitUnderlyingConnectionWhenResolved()
     {
         $base = $this->getMockBuilder('React\MySQL\ConnectionInterface')->getMock();
-        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
+        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('quit')->willReturn(new Promise(function () { }));
 
         $factory = $this->getMockBuilder('React\MySQL\Factory')->disableOriginalConstructor()->getMock();
@@ -585,8 +585,8 @@ class LazyConnectionTest extends BaseTestCase
     public function testQuitAfterPingResolvesAndEmitsCloseWhenUnderlyingConnectionQuits()
     {
         $base = $this->getMockBuilder('React\MySQL\ConnectionInterface')->getMock();
-        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
-        $base->expects($this->once())->method('quit')->willReturn(\React\Promise\resolve());
+        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
+        $base->expects($this->once())->method('quit')->willReturn(\React\Promise\resolve(null));
 
         $factory = $this->getMockBuilder('React\MySQL\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
@@ -606,7 +606,7 @@ class LazyConnectionTest extends BaseTestCase
     {
         $error = new \RuntimeException();
         $base = $this->getMockBuilder('React\MySQL\ConnectionInterface')->getMock();
-        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
+        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('quit')->willReturn(\React\Promise\reject($error));
 
         $factory = $this->getMockBuilder('React\MySQL\Factory')->disableOriginalConstructor()->getMock();
@@ -651,7 +651,7 @@ class LazyConnectionTest extends BaseTestCase
     public function testCloseTwiceAfterPingWillCloseUnderlyingConnectionWhenResolved()
     {
         $base = $this->getMockBuilder('React\MySQL\ConnectionInterface')->getMock();
-        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
+        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('close');
 
         $factory = $this->getMockBuilder('React\MySQL\Factory')->disableOriginalConstructor()->getMock();
@@ -685,7 +685,7 @@ class LazyConnectionTest extends BaseTestCase
     public function testCloseAfterPingWillCancelTimerWhenPingFromUnderlyingConnectionResolves()
     {
         $base = $this->getMockBuilder('React\MySQL\ConnectionInterface')->getMock();
-        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
+        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
 
         $factory = $this->getMockBuilder('React\MySQL\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
@@ -704,7 +704,7 @@ class LazyConnectionTest extends BaseTestCase
     public function testCloseAfterPingHasResolvedWillCloseUnderlyingConnectionWithoutTryingToCancelConnection()
     {
         $base = $this->getMockBuilder('React\MySQL\Io\LazyConnection')->setMethods(['ping', 'close'])->disableOriginalConstructor()->getMock();
-        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
+        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('close')->willReturnCallback(function () use ($base) {
             $base->emit('close');
         });
@@ -723,7 +723,7 @@ class LazyConnectionTest extends BaseTestCase
     public function testCloseAfterQuitAfterPingWillCloseUnderlyingConnectionWhenQuitIsStillPending()
     {
         $base = $this->getMockBuilder('React\MySQL\ConnectionInterface')->getMock();
-        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
+        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('quit')->willReturn(new Promise(function () { }));
         $base->expects($this->once())->method('close');
 
@@ -740,7 +740,7 @@ class LazyConnectionTest extends BaseTestCase
     public function testCloseAfterPingAfterIdleTimeoutWillCloseUnderlyingConnectionWhenQuitIsStillPending()
     {
         $base = $this->getMockBuilder('React\MySQL\ConnectionInterface')->getMock();
-        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve());
+        $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('quit')->willReturn(new Promise(function () { }));
         $base->expects($this->once())->method('close');
 

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -415,7 +415,7 @@ class ResultQueryTest extends BaseTestCase
 
         $connection->query('select * from test.book')->then(function (QueryResult $command) {
             $this->assertCount(2, $command->resultRows);
-        })->done();
+        });
 
         $connection->quit();
         Loop::run();


### PR DESCRIPTION
Builds on top of https://github.com/reactphp/promise/pull/213, https://github.com/reactphp/promise/pull/138, https://github.com/reactphp/promise/pull/224, https://github.com/reactphp/socket/pull/214 and https://github.com/reactphp/promise-stream/pull/20, https://github.com/reactphp/promise-timer/pull/54 and https://github.com/clue/reactphp-block/pull/61
Refs https://github.com/clue/reactphp-http-proxy/pull/44