### PR TITLE
Fix parsing ERR after result set

### DIFF
--- a/src/Io/Parser.php
+++ b/src/Io/Parser.php
@@ -127,7 +127,7 @@ packet:
 
         $len = $this->buffer->length();
         if ($len < $this->pctSize) {
-            $this->debug('Buffer not enouth, return');
+            $this->debug('Waiting for complete packet with ' . $len . '/' . $this->pctSize . ' bytes');
 
             return;
         }
@@ -277,6 +277,9 @@ packet:
 
     private function onError(Exception $error)
     {
+        $this->rsState      = self::RS_STATE_HEADER;
+        $this->resultFields = [];
+
         // reject current command with error if we're currently executing any commands
         // ignore unsolicited server error in case we're not executing any commands (connection will be dropped)
         if ($this->currCommand !== null) {


### PR DESCRIPTION
This changeset fixes parsing an `ERR` response after a result set. Previously, this would trigger a parser error that would corrupt the entire connection ("Not enough data in buffer").

This error situation is a bit harder to reproduce. For example, this can be triggered in a connection by invoking a `KILL QUERY n` query from a second connection. Errors for invalid queries (`SELECT unknown`) would still trigger the existing logic.

In the following diagram, we already supported the transition from `COM_QUERY_RESPONSE` to `ERR` just fine. We now also support the transition from `ROW`/`EOF` to `ERR`:

![graphviz-3ab2ba81081a7f3cc556d11fd09f50341bba6f15](https://user-images.githubusercontent.com/776829/185757894-8e4547db-e669-48da-8b1c-7b66238ee80f.png)

From https://dev.mysql.com/doc/internals/en/com-query-response.html#text-resultset

Together with the analysis in ticket #123, you're looking at ~8 hours of work, enjoy!

Refs #123