### PR TITLE
Handle parser errors by emitting error and closing connection

### DIFF
--- a/src/Io/Buffer.php
+++ b/src/Io/Buffer.php
@@ -62,6 +62,43 @@ class Buffer
     }
 
     /**
+     * Reads data with given byte length from buffer into a new buffer
+     *
+     * This class keeps consumed data in memory for performance reasons and only
+     * advances the internal buffer position by default. Reading data into a new
+     * buffer will clear the data from the original buffer to free memory.
+     *
+     * @param int $len length in bytes, must be positive or zero
+     * @return self
+     * @throws \UnderflowException
+     */
+    public function readBuffer($len)
+    {
+        // happy path to return empty buffer without any memory access for zero length string
+        if ($len === 0) {
+            return new self();
+        }
+
+        // ensure buffer size contains $len bytes by checking target buffer position
+        if ($len < 0 || !isset($this->buffer[$this->bufferPos + $len - 1])) {
+            throw new \UnderflowException('Not enough data in buffer to read ' . $len . ' bytes');
+        }
+
+        $buffer = new self();
+        $buffer->buffer = $this->read($len);
+
+        if (!isset($this->buffer[$this->bufferPos])) {
+            $this->buffer = '';
+        } else {
+            $this->buffer = \substr($this->buffer, $this->bufferPos);
+        }
+        $this->bufferPos = 0;
+
+        return $buffer;
+
+    }
+
+    /**
      * Skips binary string data with given byte length from buffer
      *
      * This method can be used instead of `read()` if you do not care about the
@@ -77,24 +114,6 @@ class Buffer
             throw new \LogicException('Not enough data in buffer');
         }
         $this->bufferPos += $len;
-    }
-
-    /**
-     * Clears all consumed data from the buffer
-     *
-     * This class keeps consumed data in memory for performance reasons and only
-     * advances the internal buffer position until this method is called.
-     *
-     * @return void
-     */
-    public function trim()
-    {
-        if (!isset($this->buffer[$this->bufferPos])) {
-            $this->buffer = '';
-        } else {
-            $this->buffer = \substr($this->buffer, $this->bufferPos);
-        }
-        $this->bufferPos = 0;
     }
 
     /**

--- a/src/Io/Buffer.php
+++ b/src/Io/Buffer.php
@@ -37,7 +37,7 @@ class Buffer
      *
      * @param int $len length in bytes, must be positive or zero
      * @return string
-     * @throws \LogicException
+     * @throws \UnderflowException
      */
     public function read($len)
     {
@@ -53,7 +53,7 @@ class Buffer
 
         // ensure buffer size contains $len bytes by checking target buffer position
         if ($len < 0 || !isset($this->buffer[$this->bufferPos + $len - 1])) {
-            throw new \LogicException('Not enough data in buffer to read ' . $len . ' bytes');
+            throw new \UnderflowException('Not enough data in buffer to read ' . $len . ' bytes');
         }
         $buffer = \substr($this->buffer, $this->bufferPos, $len);
         $this->bufferPos += $len;
@@ -106,12 +106,12 @@ class Buffer
      *
      * @param int $len length in bytes, must be positve and non-zero
      * @return void
-     * @throws \LogicException
+     * @throws \UnderflowException
      */
     public function skip($len)
     {
         if ($len < 1 || !isset($this->buffer[$this->bufferPos + $len - 1])) {
-            throw new \LogicException('Not enough data in buffer');
+            throw new \UnderflowException('Not enough data in buffer');
         }
         $this->bufferPos += $len;
     }
@@ -220,13 +220,13 @@ class Buffer
      * Reads string until NULL character
      *
      * @return string
-     * @throws \LogicException
+     * @throws \UnderflowException
      */
     public function readStringNull()
     {
         $pos = \strpos($this->buffer, "\0", $this->bufferPos);
         if ($pos === false) {
-            throw new \LogicException('Missing NULL character');
+            throw new \UnderflowException('Missing NULL character');
         }
 
         $ret = $this->read($pos - $this->bufferPos);

--- a/tests/Io/BufferTest.php
+++ b/tests/Io/BufferTest.php
@@ -22,7 +22,7 @@ class BufferTest extends BaseTestCase
 
         $buffer->append('hi');
 
-        $this->setExpectedException('LogicException');
+        $this->setExpectedException('UnderflowException');
         $buffer->read(3);
     }
 
@@ -71,7 +71,7 @@ class BufferTest extends BaseTestCase
 
         $buffer->append('hi');
 
-        $this->setExpectedException('LogicException');
+        $this->setExpectedException('UnderflowException');
         $buffer->skip(0);
     }
 
@@ -81,7 +81,7 @@ class BufferTest extends BaseTestCase
 
         $buffer->append('hi');
 
-        $this->setExpectedException('LogicException');
+        $this->setExpectedException('UnderflowException');
         $buffer->skip(3);
     }
 
@@ -214,7 +214,7 @@ class BufferTest extends BaseTestCase
         $buffer = new Buffer();
         $buffer->append("hello");
 
-        $this->setExpectedException('LogicException');
+        $this->setExpectedException('UnderflowException');
         $buffer->readStringNull();
     }
 }

--- a/tests/Io/BufferTest.php
+++ b/tests/Io/BufferTest.php
@@ -36,6 +36,35 @@ class BufferTest extends BaseTestCase
         $this->assertSame('i', $buffer->read(1));
     }
 
+    public function testReadBufferEmptyIsNoop()
+    {
+        $buffer = new Buffer();
+
+        $new = $buffer->readBuffer(0);
+
+        $this->assertSame(0, $buffer->length());
+        $this->assertSame(0, $new->length());
+    }
+
+    public function testReadBufferReturnsBufferWithOriginalLengthAndClearsOriginalBuffer()
+    {
+        $buffer = new Buffer();
+        $buffer->append('foo');
+
+        $new = $buffer->readBuffer($buffer->length());
+
+        $this->assertSame(0, $buffer->length());
+        $this->assertSame(3, $new->length());
+    }
+
+    public function testReadBufferBeyondLimitThrows()
+    {
+        $buffer = new Buffer();
+
+        $this->setExpectedException('UnderflowException');
+        $buffer->readBuffer(3);
+    }
+
     public function testSkipZeroThrows()
     {
         $buffer = new Buffer();
@@ -54,23 +83,6 @@ class BufferTest extends BaseTestCase
 
         $this->setExpectedException('LogicException');
         $buffer->skip(3);
-    }
-
-    public function testTrimEmptyIsNoop()
-    {
-        $buffer = new Buffer();
-        $buffer->trim();
-
-        $this->assertSame(0, $buffer->length());
-    }
-
-    public function testTrimDoesNotChangeLength()
-    {
-        $buffer = new Buffer();
-        $buffer->append('a');
-        $buffer->trim();
-
-        $this->assertSame(1, $buffer->length());
     }
 
     public function testParseInt1()

--- a/tests/Io/ParserTest.php
+++ b/tests/Io/ParserTest.php
@@ -132,7 +132,7 @@ class ParserTest extends BaseTestCase
 
         $stream->write("\x33\0\0\0" . "\x0a" . "mysql\0" . str_repeat("\0", 44));
         $stream->write("\x01\0\0\1" . "\x01");
-        $stream->write("\x1E\0\0\2" . "\x03" . "def" . "\0" . "\0" . "\0" . "\x09" . "sleep(10)" . "\0" . "\xC0" . "\x3F\0" . "\1\0\0\0" . "\3" . "\x81\0". "\0" . "\0\0");
+        $stream->write("\x1F\0\0\2" . "\x03" . "def" . "\0" . "\0" . "\0" . "\x09" . "sleep(10)" . "\0" . "\xC0" . "\x3F\0" . "\1\0\0\0" . "\3" . "\x81\0". "\0" . "\0\0");
         $stream->write("\x05\0\0\3" . "\xFE" . "\0\0\2\0");
         $stream->write("\x28\0\0\4" . "\xFF" . "\x25\x05" . "#abcde" . "Query execution was interrupted");
 


### PR DESCRIPTION
This changeset makes the parser more robust by splitting on individual package boundaries and handles parser errors by emitting error and closing connection. This should have no effect for well-behaving servers, but makes our parser more robust for misbehaving servers or servers sending invalid data (intentionally or otherwise).

Together with the analysis in ticket https://github.com/friends-of-reactphp/mysql/issues/123 and the work done in #158, you're looking at around two days of work, enjoy!

Builds on top of #158
Refs #123