### PR TITLE
Mark passwords and URIs as `#[\SensitiveParameter]` (PHP 8.2+)

### DIFF
--- a/src/Commands/AuthenticateCommand.php
+++ b/src/Commands/AuthenticateCommand.php
@@ -51,8 +51,13 @@ class AuthenticateCommand extends AbstractCommand
      * @param string $charset
      * @throws \InvalidArgumentException for invalid/unknown charset name
      */
-    public function __construct($user, $passwd, $dbname, $charset)
-    {
+    public function __construct(
+        $user,
+        #[\SensitiveParameter]
+        $passwd,
+        $dbname,
+        $charset
+    ) {
         if (!isset(self::$charsetMap[$charset])) {
             throw new \InvalidArgumentException('Unsupported charset selected');
         }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -156,8 +156,10 @@ class Factory
      * @param string $uri
      * @return PromiseInterface Promise<ConnectionInterface, Exception>
      */
-    public function createConnection($uri)
-    {
+    public function createConnection(
+        #[\SensitiveParameter]
+        $uri
+    ) {
         if (strpos($uri, '://') === false) {
             $uri = 'mysql://' . $uri;
         }
@@ -374,8 +376,10 @@ class Factory
      * @param string $uri
      * @return ConnectionInterface
      */
-    public function createLazyConnection($uri)
-    {
+    public function createLazyConnection(
+        #[\SensitiveParameter]
+        $uri
+    ) {
         return new LazyConnection($this, $uri, $this->loop);
     }
 }

--- a/src/Io/LazyConnection.php
+++ b/src/Io/LazyConnection.php
@@ -31,8 +31,12 @@ class LazyConnection extends EventEmitter implements ConnectionInterface
     private $idleTimer;
     private $pending = 0;
 
-    public function __construct(Factory $factory, $uri, LoopInterface $loop)
-    {
+    public function __construct(
+        Factory $factory,
+        #[\SensitiveParameter]
+        $uri,
+        LoopInterface $loop
+    ) {
         $args = [];
         \parse_str((string) \parse_url($uri, \PHP_URL_QUERY), $args);
         if (isset($args['idle'])) {


### PR DESCRIPTION
This changeset marks all passwords and URIs containing passwords as `#[\SensitiveParameter]` to avoid these parameter from potentially showing up in exception traces in PHP 8.2+. Older PHP versions are not affected by this change and continue to work as is. See also RFC: https://wiki.php.net/rfc/redact_parameters_in_back_traces

Refs #161 and #141