### PR TITLE
Change default charset encoding to `utf8mb4` for full UTF-8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,10 @@ authentication. You can explicitly pass a custom timeout value in seconds
 $factory->createConnection('localhost?timeout=0.5');
 ```
 
-By default, the connection uses the `utf8` charset encoding. Note that
-MySQL's `utf8` encoding (also known as `utf8mb3`) predates what is now
-known as UTF-8 and for historical reasons doesn't support emojis and
-other characters. If you want full UTF-8 support, you can pass the
-charset encoding like this:
+By default, the connection provides full UTF-8 support (using the
+`utf8mb4` charset encoding). This should usually not be changed for most
+applications nowadays, but for legacy reasons you can change this to use
+a different ASCII-compatible charset encoding like this:
 
 ```php
 $factory->createConnection('localhost?charset=utf8mb4');
@@ -291,11 +290,10 @@ timeout) like this:
 $factory->createLazyConnection('localhost?idle=0.1');
 ```
 
-By default, the connection uses the `utf8` charset encoding. Note that
-MySQL's `utf8` encoding (also known as `utf8mb3`) predates what is now
-known as UTF-8 and for historical reasons doesn't support emojis and
-other characters. If you want full UTF-8 support, you can pass the
-charset encoding like this:
+By default, the connection provides full UTF-8 support (using the
+`utf8mb4` charset encoding). This should usually not be changed for most
+applications nowadays, but for legacy reasons you can change this to use
+a different ASCII-compatible charset encoding like this:
 
 ```php
 $factory->createLazyConnection('localhost?charset=utf8mb4');

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -143,11 +143,10 @@ class Factory
      * $factory->createConnection('localhost?timeout=0.5');
      * ```
      *
-     * By default, the connection uses the `utf8` charset encoding. Note that
-     * MySQL's `utf8` encoding (also known as `utf8mb3`) predates what is now
-     * known as UTF-8 and for historical reasons doesn't support emojis and
-     * other characters. If you want full UTF-8 support, you can pass the
-     * charset encoding like this:
+     * By default, the connection provides full UTF-8 support (using the
+     * `utf8mb4` charset encoding). This should usually not be changed for most
+     * applications nowadays, but for legacy reasons you can change this to use
+     * a different ASCII-compatible charset encoding like this:
      *
      * ```php
      * $factory->createConnection('localhost?charset=utf8mb4');
@@ -183,7 +182,7 @@ class Factory
                 isset($parts['user']) ? rawurldecode($parts['user']) : 'root',
                 isset($parts['pass']) ? rawurldecode($parts['pass']) : '',
                 isset($parts['path']) ? rawurldecode(ltrim($parts['path'], '/')) : '',
-                isset($args['charset']) ? $args['charset'] : 'utf8'
+                isset($args['charset']) ? $args['charset'] : 'utf8mb4'
             );
         } catch (\InvalidArgumentException $e) {
             return \React\Promise\reject($e);
@@ -363,11 +362,10 @@ class Factory
      * $factory->createLazyConnection('localhost?idle=0.1');
      * ```
      *
-     * By default, the connection uses the `utf8` charset encoding. Note that
-     * MySQL's `utf8` encoding (also known as `utf8mb3`) predates what is now
-     * known as UTF-8 and for historical reasons doesn't support emojis and
-     * other characters. If you want full UTF-8 support, you can pass the
-     * charset encoding like this:
+     * By default, the connection provides full UTF-8 support (using the
+     * `utf8mb4` charset encoding). This should usually not be changed for most
+     * applications nowadays, but for legacy reasons you can change this to use
+     * a different ASCII-compatible charset encoding like this:
      *
      * ```php
      * $factory->createLazyConnection('localhost?charset=utf8mb4');

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -361,7 +361,7 @@ class ResultQueryTest extends BaseTestCase
         $connection->query('SELECT @@character_set_client')->then(function (QueryResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
-            $this->assertSame('utf8', reset($command->resultRows[0]));
+            $this->assertSame('utf8mb4', reset($command->resultRows[0]));
         });
 
         $connection->quit();


### PR DESCRIPTION
This changeset updates the MySQL client to use `utf8mb4` as the default charset encoding for full UTF-8 support instead of the legacy `utf8mb3` charset encoding that was previously used for BC reasons. The `utf8mb4` encoding is available as of MySQL 5.5.3 (released early 2010) and is what most applications would want to use nowadays. For legacy reasons you can still change this to use a different ASCII-compatible charset encoding like this:

```php
$factory->createConnection('localhost?charset=utf8mb4');
```

Builds on top of #135