### PR TITLE
Updated implementation of query named parameters

### DIFF
--- a/tests/Io/QueryTest.php
+++ b/tests/Io/QueryTest.php
@@ -35,29 +35,40 @@ class QueryTest extends TestCase
             'name' => 'test'
         ])->getSql();
         $this->assertEquals("select * from test where id = 100 and name = 'test'", $sql);
+    }
 
+    public function testNamedParamsWithPrefix()
+    {
         $query = new Query('select * from test where id = :id and name = :name');
         $sql   = $query->bindParamsFromArray([
             ':id' => 100,
             ':name' => 'test'
         ])->getSql();
         $this->assertEquals("select * from test where id = 100 and name = 'test'", $sql);
+    }
 
+    public function testNamedParamsWithInClause()
+    {
         $query = new Query('select * from test where id in (:in) and name = :name');
         $sql   = $query->bindParamsFromArray([
             'in' => [1, 2],
             'name' => 'test'
         ])->getSql();
         $this->assertEquals("select * from test where id in (1,2) and name = 'test'", $sql);
+    }
 
-        // mixed named & ?
+    public function testMixedNamedParams()
+    {
         $query = new Query('select * from test where id in (?) and name = :name');
         $sql   = $query->bindParamsFromArray([
             [1, 2],
             'name' => 'test'
         ])->getSql();
         $this->assertEquals("select * from test where id in (1,2) and name = 'test'", $sql);
+    }
 
+    public function testMixedNamedParamsWithInClause()
+    {
         $query = new Query('select * from test where id in (:in) and name = ?');
         $sql   = $query->bindParamsFromArray([
             'in' => [1, 2],


### PR DESCRIPTION
Hello!

I saw [a previous pull request about the named parameters](https://github.com/friends-of-reactphp/mysql/pull/43). Since there is no activity for 3 years now, I took the liberty to make my own implementation and update the unit tests.

It allows:

```php
$connection->query('SELECT * FROM my_table WHERE foo = :param', ['param' => 'bar']);
```
```php
$connection->query('SELECT * FROM my_table WHERE foo = :param', [':param' => 'bar']);
```
```php
$connection->query('SELECT * FROM my_table WHERE foo = :param AND param2 = ?', ['param' => 'bar', 'param2Value']);
```

Of course, all the previous ways of querying still work.
I can update the README if needed.