### PR TITLE
Improve CI workflow to await database

### DIFF
--- a/tests/wait-for-mysql.sh
+++ b/tests/wait-for-mysql.sh
@@ -3,6 +3,6 @@
 CONTAINER="mysql"
 USERNAME="test"
 PASSWORD="test"
-while ! docker exec $CONTAINER mysql --user=$USERNAME --password=$PASSWORD -e "SELECT 1" >/dev/null 2>&1; do
+while ! docker exec $CONTAINER mysql --host=127.0.0.1 --port=3306 --user=$USERNAME --password=$PASSWORD -e "SELECT 1" >/dev/null 2>&1; do
     sleep 1
 done


### PR DESCRIPTION
We recently encountered failing test runs in our CI matrix with an error response like this (nearly all tests failed with this same error response): 
![image](https://github.com/friends-of-reactphp/mysql/assets/44357440/5cf1e7af-ed55-47d5-b88d-3d6984b9a61f)

These failures occurred only occasionally, indicating some kind of race condition. A while ago, we introduced the
`wait-for-mysql.sh` file in pull request #132. This file waits for the internal database to be ready to handle SQL queries before running our PHPUnit tests. However, while this file waited for the internal part of Docker to be ready, the external port was always opened just moments after the database became ready to handle SQL queries. As a result, our test suite failed because the tests couldn't establish a connection to the database.

This pull request now fixes this issue by explicitly using the `--host` & `--port` configuration option. I tested this in my fork by running the test suite multiple times without encountering any failures.

Builds on top of #132 and others 