### PR TITLE
Reduce default idle time to 1ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ It is written in pure PHP and does not require any extensions.
 This example runs a simple `SELECT` query and dumps all the records from a `book` table:
 
 ```php
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
 $factory = new React\MySQL\Factory();
 $connection = $factory->createLazyConnection('user:pass@localhost/bookstore');
 
@@ -54,8 +58,6 @@ $connection->query('SELECT * FROM book')->then(
         echo 'Error: ' . $error->getMessage() . PHP_EOL;
     }
 );
-
-$connection->quit();
 ```
 
 See also the [examples](examples).
@@ -202,9 +204,11 @@ This method immediately returns a "virtual" connection implementing the
 interface with your MySQL database. Internally, it lazily creates the
 underlying database connection only on demand once the first request is
 invoked on this instance and will queue all outstanding requests until
-the underlying connection is ready. Additionally, it will only keep this
-underlying connection in an "idle" state for 60s by default and will
-automatically end the underlying connection when it is no longer needed.
+the underlying connection is ready. This underlying connection will be
+reused for all requests until it is closed. By default, idle connections
+will be held open for 1ms (0.001s) when not used. The next request will
+either reuse the existing connection or will automatically create a new
+underlying connection if this idle time is expired.
 
 From a consumer side this means that you can start sending queries to the
 database right away while the underlying connection may still be
@@ -277,17 +281,17 @@ in seconds (or use a negative number to not apply a timeout) like this:
 $factory->createLazyConnection('localhost?timeout=0.5');
 ```
 
-By default, this method will keep "idle" connection open for 60s and will
-then end the underlying connection. The next request after an "idle"
-connection ended will automatically create a new underlying connection.
-This ensure you always get a "fresh" connection and as such should not be
-confused with a "keepalive" or "heartbeat" mechanism, as this will not
-actively try to probe the connection. You can explicitly pass a custom
-idle timeout value in seconds (or use a negative number to not apply a
-timeout) like this:
+By default, idle connections will be held open for 1ms (0.001s) when not
+used. The next request will either reuse the existing connection or will
+automatically create a new underlying connection if this idle time is
+expired. This ensures you always get a "fresh" connection and as such
+should not be confused with a "keepalive" or "heartbeat" mechanism, as
+this will not actively try to probe the connection. You can explicitly
+pass a custom idle timeout value in seconds (or use a negative number to
+not apply a timeout) like this:
 
 ```php
-$factory->createLazyConnection('localhost?idle=0.1');
+$factory->createLazyConnection('localhost?idle=10.0');
 ```
 
 By default, the connection provides full UTF-8 support (using the

--- a/examples/01-query.php
+++ b/examples/01-query.php
@@ -29,5 +29,3 @@ $connection->query($query)->then(function (QueryResult $command) {
     // the query was not executed successfully
     echo 'Error: ' . $error->getMessage() . PHP_EOL;
 });
-
-$connection->quit();

--- a/examples/02-query-stream.php
+++ b/examples/02-query-stream.php
@@ -24,5 +24,3 @@ $stream->on('error', function (Exception $e) {
 $stream->on('close', function () {
     echo 'CLOSED' . PHP_EOL;
 });
-
-$connection->quit();

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -276,9 +276,11 @@ class Factory
      * interface with your MySQL database. Internally, it lazily creates the
      * underlying database connection only on demand once the first request is
      * invoked on this instance and will queue all outstanding requests until
-     * the underlying connection is ready. Additionally, it will only keep this
-     * underlying connection in an "idle" state for 60s by default and will
-     * automatically end the underlying connection when it is no longer needed.
+     * the underlying connection is ready. This underlying connection will be
+     * reused for all requests until it is closed. By default, idle connections
+     * will be held open for 1ms (0.001s) when not used. The next request will
+     * either reuse the existing connection or will automatically create a new
+     * underlying connection if this idle time is expired.
      *
      * From a consumer side this means that you can start sending queries to the
      * database right away while the underlying connection may still be
@@ -351,17 +353,17 @@ class Factory
      * $factory->createLazyConnection('localhost?timeout=0.5');
      * ```
      *
-     * By default, this method will keep "idle" connection open for 60s and will
-     * then end the underlying connection. The next request after an "idle"
-     * connection ended will automatically create a new underlying connection.
-     * This ensure you always get a "fresh" connection and as such should not be
-     * confused with a "keepalive" or "heartbeat" mechanism, as this will not
-     * actively try to probe the connection. You can explicitly pass a custom
-     * idle timeout value in seconds (or use a negative number to not apply a
-     * timeout) like this:
+     * By default, idle connections will be held open for 1ms (0.001s) when not
+     * used. The next request will either reuse the existing connection or will
+     * automatically create a new underlying connection if this idle time is
+     * expired. This ensures you always get a "fresh" connection and as such
+     * should not be confused with a "keepalive" or "heartbeat" mechanism, as
+     * this will not actively try to probe the connection. You can explicitly
+     * pass a custom idle timeout value in seconds (or use a negative number to
+     * not apply a timeout) like this:
      *
      * ```php
-     * $factory->createLazyConnection('localhost?idle=0.1');
+     * $factory->createLazyConnection('localhost?idle=10.0');
      * ```
      *
      * By default, the connection provides full UTF-8 support (using the

--- a/src/Io/LazyConnection.php
+++ b/src/Io/LazyConnection.php
@@ -27,7 +27,7 @@ class LazyConnection extends EventEmitter implements ConnectionInterface
     private $disconnecting;
 
     private $loop;
-    private $idlePeriod = 60.0;
+    private $idlePeriod = 0.001;
     private $idleTimer;
     private $pending = 0;
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -602,7 +602,7 @@ class FactoryTest extends BaseTestCase
     {
         $factory = new Factory();
 
-        $uri = $this->getConnectionString() . '?idle=0';
+        $uri = $this->getConnectionString();
         $connection = $factory->createLazyConnection($uri);
 
         $connection->ping();

--- a/tests/Io/LazyConnectionTest.php
+++ b/tests/Io/LazyConnectionTest.php
@@ -218,7 +218,7 @@ class LazyConnectionTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
-        $loop->expects($this->once())->method('addTimer')->with(60.0, $this->anything());
+        $loop->expects($this->once())->method('addTimer')->with(0.001, $this->anything());
 
         $connection = new LazyConnection($factory, '', $loop);
 


### PR DESCRIPTION
This simple changeset reduces the default idle time to 1ms (previously 60s). This makes it easier to use lazy connections also in short-lived applications as you no longer have to wait for it to time out for most common use cases.

The idle time can be configured using the `?idle=10.0` parameter as usual for more specific requirements. This can be particularly useful if you have a long-running application with sporadic requests to MySQL and a noticeable overhead for (re-)creating the underlying connection over a slow network.

I've also looked into renaming the "idle" time to "keepalive" but feel this would be misworded at this point. The "idle" time only defines the time the client is willing to keep the underlying connection alive without trying to automatically close it. Specifically, the mechanism does not include any messages to actively keep the connection alive using heartbeat messages.

Builds on top of #88, #87 and https://github.com/clue/reactphp-redis/pull/130
Refs #147