### PR TITLE
Use Promise v3 template types

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $factory = new React\MySQL\Factory(null, $connector);
 
 #### createConnection()
 
-The `createConnection(string $url): PromiseInterface<ConnectionInterface, Exception>` method can be used to
+The `createConnection(string $url): PromiseInterface<ConnectionInterface>` method can be used to
 create a new [`ConnectionInterface`](#connectioninterface).
 
 It helps with establishing a TCP/IP connection to your MySQL database
@@ -311,7 +311,7 @@ and sending your database queries.
 
 #### query()
 
-The `query(string $query, array $params = []): PromiseInterface` method can be used to
+The `query(string $query, array $params = []): PromiseInterface<QueryResult>` method can be used to
 perform an async query.
 
 This method returns a promise that will resolve with a `QueryResult` on
@@ -424,7 +424,7 @@ suited for exposing multiple possible results.
 
 #### ping()
 
-The `ping(): PromiseInterface<void, Exception>` method can be used to
+The `ping(): PromiseInterface<void>` method can be used to
 check that the connection is alive.
 
 This method returns a promise that will resolve (with a void value) on
@@ -443,7 +443,7 @@ $connection->ping()->then(function () {
 
 #### quit()
 
-The `quit(): PromiseInterface<void, Exception>` method can be used to
+The `quit(): PromiseInterface<void>` method can be used to
 quit (soft-close) the connection.
 
 This method returns a promise that will resolve (with a void value) on

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -98,7 +98,8 @@ interface ConnectionInterface extends EventEmitterInterface
      *
      * @param string $sql    SQL statement
      * @param array  $params Parameters which should be bound to query
-     * @return PromiseInterface Returns a Promise<QueryResult,Exception>
+     * @return PromiseInterface<QueryResult>
+     *     Resolves with a `QueryResult` on success or rejects with an `Exception` on error.
      */
     public function query($sql, array $params = []);
 
@@ -180,7 +181,8 @@ interface ConnectionInterface extends EventEmitterInterface
      * });
      * ```
      *
-     * @return PromiseInterface Returns a Promise<true,Exception>
+     * @return PromiseInterface<void>
+     *     Resolves with a `void` value on success or rejects with an `Exception` on error.
      */
     public function ping();
 
@@ -198,7 +200,8 @@ interface ConnectionInterface extends EventEmitterInterface
      * $connection->quit();
      * ```
      *
-     * @return PromiseInterface Returns a Promise<void,Exception>
+     * @return PromiseInterface<void>
+     *     Resolves with a `void` value on success or rejects with an `Exception` on error.
      */
     public function quit();
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -153,7 +153,8 @@ class Factory
      * ```
      *
      * @param string $uri
-     * @return PromiseInterface Promise<ConnectionInterface, Exception>
+     * @return PromiseInterface<ConnectionInterface>
+     *     Resolves with a `ConnectionInterface` on success or rejects with an `Exception` on error.
      */
     public function createConnection(
         #[\SensitiveParameter]


### PR DESCRIPTION
This simple changeset adds proper Promise v3 template types to describe API arguments and return values. The change is pretty straightforward, as most of the work was done upstream and in previous PRs linked below.

Note that this project doesn't currently use PHPStan itself, so this is a bit harder to reproduce on its own. I've tested this in a number of downstream projects and it appears this is the minimal changeset required to make downstream projects work that depend on these functions. I'll link relevant PRs against this one for reference.

I'd vote to get this in as is for now to make sure we unblock any downstream projects. Note that this doesn't preclude how and/or whether we're going to integrate PHPStan into pre-v3 components like this one as already discussed in reactphp/async#77.

Builds on top of reactphp/promise#247 and #157