### PR TITLE
Hello `0.7.x` development branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 
 Async MySQL database client for [ReactPHP](https://reactphp.org/).
 
+> **Development version:** This branch contains the code for the upcoming
+> version 0.7 release. For the code of the current stable version 0.6 release, check
+> out the [`0.6.x` branch](https://github.com/friends-of-reactphp/mysql/tree/0.6.x).
+>
+> The upcoming version 0.7 release will be the way forward for this package.
+> However, we will still actively support version 0.6 for those not yet on the
+> latest version.
+> See also [installation instructions](#install) for more details.
+
 This is a MySQL database driver for [ReactPHP](https://reactphp.org/).
 It implements the MySQL protocol and allows you to access your existing MySQL
 database.
@@ -502,11 +511,11 @@ See also the [`close()`](#close) method.
 The recommended way to install this library is [through Composer](https://getcomposer.org/).
 [New to Composer?](https://getcomposer.org/doc/00-intro.md)
 
-This project follows [SemVer](https://semver.org/).
-This will install the latest supported version:
+Once released, this project will follow [SemVer](https://semver.org/).
+At the moment, this will install the latest development version:
 
 ```bash
-composer require react/mysql:^0.6
+composer require react/mysql:^0.7@dev
 ```
 
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.


### PR DESCRIPTION
Once this PR is merged, we can start working on the new [v0.7.0 milestone](https://github.com/friends-of-reactphp/mysql/milestone/18). The default branch will be `0.7.x` and the old `0.6.x` branch still stay in place at least until `0.7.0` is released.

Refs #164 and https://github.com/reactphp/async/pull/29