### PR TITLE
Rename `QueryResult` to `MysqlResult`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ require __DIR__ . '/vendor/autoload.php';
 $mysql = new React\MySQL\MysqlClient('user:pass@localhost/bookstore');
 
 $mysql->query('SELECT * FROM book')->then(
-    function (React\MySQL\QueryResult $command) {
+    function (React\MySQL\MysqlResult $command) {
         print_r($command->resultFields);
         print_r($command->resultRows);
         echo count($command->resultRows) . ' row(s) in set' . PHP_EOL;
@@ -202,10 +202,10 @@ given event loop instance.
 
 #### query()
 
-The `query(string $query, array $params = []): PromiseInterface<QueryResult>` method can be used to
+The `query(string $query, array $params = []): PromiseInterface<MysqlResult>` method can be used to
 perform an async query.
 
-This method returns a promise that will resolve with a `QueryResult` on
+This method returns a promise that will resolve with a `MysqlResult` on
 success or will reject with an `Exception` on error. The MySQL protocol
 is inherently sequential, so that all queries will be performed in order
 and outstanding queries will be put into a queue to be executed once the
@@ -225,7 +225,7 @@ unknown or known to be too large to fit into memory, you should use the
 [`queryStream()`](#querystream) method instead.
 
 ```php
-$mysql->query($query)->then(function (QueryResult $command) {
+$mysql->query($query)->then(function (React\MySQL\MysqlResult $command) {
     if (isset($command->resultRows)) {
         // this is a response to a SELECT etc. with some rows (0+)
         print_r($command->resultFields);

--- a/examples/01-query.php
+++ b/examples/01-query.php
@@ -8,7 +8,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $mysql = new React\MySQL\MysqlClient(getenv('MYSQL_URI') ?: 'test:test@localhost/test');
 
 $query = isset($argv[1]) ? $argv[1] : 'select * from book';
-$mysql->query($query)->then(function (React\MySQL\QueryResult $command) {
+$mysql->query($query)->then(function (React\MySQL\MysqlResult $command) {
     if (isset($command->resultRows)) {
         // this is a response to a SELECT etc. with some rows (0+)
         print_r($command->resultFields);

--- a/examples/11-interactive.php
+++ b/examples/11-interactive.php
@@ -25,7 +25,7 @@ $stdin->on('data', function ($line) use ($mysql) {
     }
 
     $time = microtime(true);
-    $mysql->query($query)->then(function (React\MySQL\QueryResult $command) use ($time) {
+    $mysql->query($query)->then(function (React\MySQL\MysqlResult $command) use ($time) {
         if (isset($command->resultRows)) {
             // this is a response to a SELECT etc. with some rows (0+)
             echo implode("\t", array_column($command->resultFields, 'name')) . PHP_EOL;

--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -8,7 +8,7 @@ use React\MySQL\Commands\PingCommand;
 use React\MySQL\Commands\QueryCommand;
 use React\MySQL\Commands\QuitCommand;
 use React\MySQL\Exception;
-use React\MySQL\QueryResult;
+use React\MySQL\MysqlResult;
 use React\Promise\Deferred;
 use React\Promise\Promise;
 use React\Socket\ConnectionInterface as SocketConnectionInterface;
@@ -79,7 +79,7 @@ class Connection extends EventEmitter
             $rows[] = $row;
         });
         $command->on('end', function () use ($command, $deferred, &$rows) {
-            $result = new QueryResult();
+            $result = new MysqlResult();
             $result->resultFields = $command->fields;
             $result->resultRows = $rows;
             $result->warningCount = $command->warningCount;
@@ -94,7 +94,7 @@ class Connection extends EventEmitter
             $deferred->reject($error);
         });
         $command->on('success', function () use ($command, $deferred) {
-            $result = new QueryResult();
+            $result = new MysqlResult();
             $result->affectedRows = $command->affectedRows;
             $result->insertId = $command->insertId;
             $result->warningCount = $command->warningCount;

--- a/src/MysqlClient.php
+++ b/src/MysqlClient.php
@@ -151,7 +151,7 @@ class MysqlClient extends EventEmitter
     /**
      * Performs an async query.
      *
-     * This method returns a promise that will resolve with a `QueryResult` on
+     * This method returns a promise that will resolve with a `MysqlResult` on
      * success or will reject with an `Exception` on error. The MySQL protocol
      * is inherently sequential, so that all queries will be performed in order
      * and outstanding queries will be put into a queue to be executed once the
@@ -171,7 +171,7 @@ class MysqlClient extends EventEmitter
      * [`queryStream()`](#querystream) method instead.
      *
      * ```php
-     * $mysql->query($query)->then(function (QueryResult $command) {
+     * $mysql->query($query)->then(function (React\MySQL\MysqlResult $command) {
      *     if (isset($command->resultRows)) {
      *         // this is a response to a SELECT etc. with some rows (0+)
      *         print_r($command->resultFields);
@@ -204,8 +204,8 @@ class MysqlClient extends EventEmitter
      *
      * @param string $sql    SQL statement
      * @param array  $params Parameters which should be bound to query
-     * @return PromiseInterface<QueryResult>
-     *     Resolves with a `QueryResult` on success or rejects with an `Exception` on error.
+     * @return PromiseInterface<MysqlResult>
+     *     Resolves with a `MysqlResult` on success or rejects with an `Exception` on error.
      */
     public function query($sql, array $params = [])
     {
@@ -216,7 +216,7 @@ class MysqlClient extends EventEmitter
         return $this->connecting()->then(function (Connection $connection) use ($sql, $params) {
             $this->awake();
             return $connection->query($sql, $params)->then(
-                function (QueryResult $result) {
+                function (MysqlResult $result) {
                     $this->idle();
                     return $result;
                 },

--- a/src/MysqlResult.php
+++ b/src/MysqlResult.php
@@ -2,7 +2,7 @@
 
 namespace React\MySQL;
 
-class QueryResult
+class MysqlResult
 {
     /**
      * last inserted ID (if any)

--- a/tests/MysqlClientTest.php
+++ b/tests/MysqlClientTest.php
@@ -4,7 +4,7 @@ namespace React\Tests\MySQL\Io;
 
 use React\MySQL\Io\Connection;
 use React\MySQL\MysqlClient;
-use React\MySQL\QueryResult;
+use React\MySQL\MysqlResult;
 use React\Promise\Deferred;
 use React\Promise\Promise;
 use React\Promise\PromiseInterface;
@@ -308,7 +308,7 @@ class MysqlClientTest extends BaseTestCase
 
     public function testQueryWillResolveAndStartTimerWithDefaultIntervalWhenQueryFromUnderlyingConnectionResolves()
     {
-        $result = new QueryResult();
+        $result = new MysqlResult();
 
         $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('query')->with('SELECT 1')->willReturn(\React\Promise\resolve($result));
@@ -331,7 +331,7 @@ class MysqlClientTest extends BaseTestCase
 
     public function testQueryWillResolveAndStartTimerWithIntervalFromIdleParameterWhenQueryFromUnderlyingConnectionResolves()
     {
-        $result = new QueryResult();
+        $result = new MysqlResult();
 
         $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('query')->with('SELECT 1')->willReturn(\React\Promise\resolve($result));
@@ -354,7 +354,7 @@ class MysqlClientTest extends BaseTestCase
 
     public function testQueryWillResolveWithoutStartingTimerWhenQueryFromUnderlyingConnectionResolvesAndIdleParameterIsNegative()
     {
-        $result = new QueryResult();
+        $result = new MysqlResult();
 
         $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('query')->with('SELECT 1')->willReturn(\React\Promise\resolve($result));
@@ -377,7 +377,7 @@ class MysqlClientTest extends BaseTestCase
 
     public function testQueryBeforePingWillResolveWithoutStartingTimerWhenQueryFromUnderlyingConnectionResolvesBecausePingIsStillPending()
     {
-        $result = new QueryResult();
+        $result = new MysqlResult();
         $deferred = new Deferred();
 
         $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();

--- a/tests/NoResultQueryTest.php
+++ b/tests/NoResultQueryTest.php
@@ -4,7 +4,7 @@ namespace React\Tests\MySQL;
 
 use React\EventLoop\Loop;
 use React\MySQL\MysqlClient;
-use React\MySQL\QueryResult;
+use React\MySQL\MysqlResult;
 
 class NoResultQueryTest extends BaseTestCase
 {
@@ -27,7 +27,7 @@ class NoResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('update book set created=999 where id=999')->then(function (QueryResult $command) {
+        $connection->query('update book set created=999 where id=999')->then(function (MysqlResult $command) {
             $this->assertEquals(0, $command->affectedRows);
         });
 
@@ -39,7 +39,7 @@ class NoResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query("insert into book (`name`) values ('foo')")->then(function (QueryResult $command) {
+        $connection->query("insert into book (`name`) values ('foo')")->then(function (MysqlResult $command) {
             $this->assertEquals(1, $command->affectedRows);
             $this->assertEquals(1, $command->insertId);
         });
@@ -53,7 +53,7 @@ class NoResultQueryTest extends BaseTestCase
         $connection = $this->createConnection(Loop::get());
 
         $connection->query("insert into book (`name`) values ('foo')");
-        $connection->query('update book set created=999 where id=1')->then(function (QueryResult $command) {
+        $connection->query('update book set created=999 where id=1')->then(function (MysqlResult $command) {
             $this->assertEquals(1, $command->affectedRows);
         });
 
@@ -75,7 +75,7 @@ CREATE TABLE IF NOT EXISTS `book` (
     PRIMARY KEY (`id`)
 )';
 
-        $connection->query($sql)->then(function (QueryResult $command) {
+        $connection->query($sql)->then(function (MysqlResult $command) {
             $this->assertEquals(1, $command->warningCount);
         });
 

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -5,7 +5,7 @@ namespace React\Tests\MySQL;
 use React\EventLoop\Loop;
 use React\MySQL\Io\Constants;
 use React\MySQL\MysqlClient;
-use React\MySQL\QueryResult;
+use React\MySQL\MysqlResult;
 
 class ResultQueryTest extends BaseTestCase
 {
@@ -13,7 +13,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select \'foo\'')->then(function (QueryResult $command) {
+        $connection->query('select \'foo\'')->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertSame('foo', reset($command->resultRows[0]));
@@ -51,7 +51,7 @@ class ResultQueryTest extends BaseTestCase
 
         $expected = $value;
 
-        $connection->query('select ?', [$value])->then(function (QueryResult $command) use ($expected) {
+        $connection->query('select ?', [$value])->then(function (MysqlResult $command) use ($expected) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertSame($expected, reset($command->resultRows[0]));
@@ -76,7 +76,7 @@ class ResultQueryTest extends BaseTestCase
         $expected = $value;
 
         $connection->query('SET SQL_MODE="NO_BACKSLASH_ESCAPES"');
-        $connection->query('select ?', [$value])->then(function (QueryResult $command) use ($expected) {
+        $connection->query('select ?', [$value])->then(function (MysqlResult $command) use ($expected) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertSame($expected, reset($command->resultRows[0]));
@@ -103,7 +103,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select ?', [$value])->then(function (QueryResult $command) use ($expected) {
+        $connection->query('select ?', [$value])->then(function (MysqlResult $command) use ($expected) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertSame($expected, reset($command->resultRows[0]));
@@ -117,7 +117,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select \'hello?\'')->then(function (QueryResult $command) {
+        $connection->query('select \'hello?\'')->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertEquals('hello?', reset($command->resultRows[0]));
@@ -134,7 +134,7 @@ class ResultQueryTest extends BaseTestCase
         $length = 40000;
         $value = str_repeat('.', $length);
 
-        $connection->query('SELECT ?', [$value])->then(function (QueryResult $command) use ($length) {
+        $connection->query('SELECT ?', [$value])->then(function (MysqlResult $command) use ($length) {
             $this->assertCount(1, $command->resultFields);
             $this->assertEquals($length * 4, $command->resultFields[0]['length']);
             $this->assertSame(Constants::FIELD_TYPE_VAR_STRING, $command->resultFields[0]['type']);
@@ -148,7 +148,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select \'foo\' as ``')->then(function (QueryResult $command) {
+        $connection->query('select \'foo\' as ``')->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertSame('foo', reset($command->resultRows[0]));
@@ -166,7 +166,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select null')->then(function (QueryResult $command) {
+        $connection->query('select null')->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertNull(reset($command->resultRows[0]));
@@ -183,7 +183,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select "foo" UNION select "bar"')->then(function (QueryResult $command) {
+        $connection->query('select "foo" UNION select "bar"')->then(function (MysqlResult $command) {
             $this->assertCount(2, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -199,7 +199,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select "foo" UNION select null')->then(function (QueryResult $command) {
+        $connection->query('select "foo" UNION select null')->then(function (MysqlResult $command) {
             $this->assertCount(2, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -218,7 +218,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select 0 UNION select null')->then(function (QueryResult $command) {
+        $connection->query('select 0 UNION select null')->then(function (MysqlResult $command) {
             $this->assertCount(2, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -237,7 +237,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select "foo" UNION select 1')->then(function (QueryResult $command) {
+        $connection->query('select "foo" UNION select 1')->then(function (MysqlResult $command) {
             $this->assertCount(2, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -256,7 +256,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select "foo" UNION select ""')->then(function (QueryResult $command) {
+        $connection->query('select "foo" UNION select ""')->then(function (MysqlResult $command) {
             $this->assertCount(2, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -272,7 +272,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select "foo" LIMIT 0')->then(function (QueryResult $command) {
+        $connection->query('select "foo" LIMIT 0')->then(function (MysqlResult $command) {
             $this->assertCount(0, $command->resultRows);
 
             $this->assertCount(1, $command->resultFields);
@@ -287,7 +287,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select "foo","bar"')->then(function (QueryResult $command) {
+        $connection->query('select "foo","bar"')->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(2, $command->resultRows[0]);
 
@@ -303,7 +303,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select "foo",""')->then(function (QueryResult $command) {
+        $connection->query('select "foo",""')->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(2, $command->resultRows[0]);
 
@@ -319,7 +319,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select \'\' as `first`, \'\' as `second`')->then(function (QueryResult $command) {
+        $connection->query('select \'\' as `first`, \'\' as `second`')->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(2, $command->resultRows[0]);
             $this->assertSame(['', ''], array_values($command->resultRows[0]));
@@ -337,7 +337,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select "foo" as `col`,"bar" as `col`')->then(function (QueryResult $command) {
+        $connection->query('select "foo" as `col`,"bar" as `col`')->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -356,7 +356,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('SELECT @@character_set_client')->then(function (QueryResult $command) {
+        $connection->query('SELECT @@character_set_client')->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertSame('utf8mb4', reset($command->resultRows[0]));
@@ -371,7 +371,7 @@ class ResultQueryTest extends BaseTestCase
         $uri = $this->getConnectionString() . '?charset=latin1';
         $connection = new MysqlClient($uri);
 
-        $connection->query('SELECT @@character_set_client')->then(function (QueryResult $command) {
+        $connection->query('SELECT @@character_set_client')->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertSame('latin1', reset($command->resultRows[0]));
@@ -391,7 +391,7 @@ class ResultQueryTest extends BaseTestCase
         $connection->query("insert into book (`name`) values ('foo')");
         $connection->query("insert into book (`name`) values ('bar')");
 
-        $connection->query('select * from book')->then(function (QueryResult $command) {
+        $connection->query('select * from book')->then(function (MysqlResult $command) {
             $this->assertCount(2, $command->resultRows);
         });
 
@@ -407,7 +407,7 @@ class ResultQueryTest extends BaseTestCase
         $uri = $this->getConnectionString(['dbname' => '']);
         $connection = new MysqlClient($uri);
 
-        $connection->query('select * from test.book')->then(function (QueryResult $command) {
+        $connection->query('select * from test.book')->then(function (MysqlResult $command) {
             $this->assertCount(2, $command->resultRows);
         });
 
@@ -459,7 +459,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = $this->createConnection(Loop::get());
 
         Loop::addTimer(0.1, function () use ($connection) {
-            $connection->query('select 1+1')->then(function (QueryResult $command) {
+            $connection->query('select 1+1')->then(function (MysqlResult $command) {
                 $this->assertEquals([['1+1' => 2]], $command->resultRows);
             });
             $connection->quit();


### PR DESCRIPTION
In this pull request, I propose changing the current `QueryResult` to `MysqlResult`. This change aligns with the recently introduced `MysqlClient` from #186, ensuring a consistent "Mysql" prefix throughout.

The name "QueryResult" is not incorrect in this case. However, when working with multiple database clients in one project, it can lead to confusion about which specific "query result" is being referred to. For instance, the https://github.com/clue/reactphp-sqlite project has a similar class named `Result`, which should also be renamed to something like `SqliteResult` in the future.

Furthermore, we applied a similar reasoning in https://github.com/reactphp/socket/pull/263 and https://github.com/reactphp/http/pull/417.

Refs #147
Builds on top of #186