### PR TITLE
Rename `MySQL` namespace to `Mysql`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ This example runs a simple `SELECT` query and dumps all the records from a `book
 
 require __DIR__ . '/vendor/autoload.php';
 
-$mysql = new React\MySQL\MysqlClient('user:pass@localhost/bookstore');
+$mysql = new React\Mysql\MysqlClient('user:pass@localhost/bookstore');
 
 $mysql->query('SELECT * FROM book')->then(
-    function (React\MySQL\MysqlResult $command) {
+    function (React\Mysql\MysqlResult $command) {
         print_r($command->resultFields);
         print_r($command->resultRows);
         echo count($command->resultRows) . ' row(s) in set' . PHP_EOL;
@@ -68,7 +68,7 @@ The `MysqlClient` is responsible for exchanging messages with your MySQL server
 and keeps track of pending queries.
 
 ```php
-$mysql = new React\MySQL\MysqlClient($uri);
+$mysql = new React\Mysql\MysqlClient($uri);
 
 $mysql->query(…);
 ```
@@ -114,7 +114,7 @@ The `$uri` parameter must contain the database host, optional
 authentication, port and database to connect to:
 
 ```php
-$mysql = new React\MySQL\MysqlClient('user:secret@localhost:3306/database');
+$mysql = new React\Mysql\MysqlClient('user:secret@localhost:3306/database');
 ```
 
 Note that both the username and password must be URL-encoded (percent-encoded)
@@ -124,7 +124,7 @@ if they contain special characters:
 $user = 'he:llo';
 $pass = 'p@ss';
 
-$mysql = new React\MySQL\MysqlClient(
+$mysql = new React\Mysql\MysqlClient(
     rawurlencode($user) . ':' . rawurlencode($pass) . '@localhost:3306/db'
 );
 ```
@@ -132,7 +132,7 @@ $mysql = new React\MySQL\MysqlClient(
 You can omit the port if you're connecting to default port `3306`:
 
 ```php
-$mysql = new React\MySQL\MysqlClient('user:secret@localhost/database');
+$mysql = new React\Mysql\MysqlClient('user:secret@localhost/database');
 ```
 
 If you do not include authentication and/or database, then this method
@@ -141,7 +141,7 @@ and no database selected. This may be useful when initially setting up a
 database, but likely to yield an authentication error in a production system:
 
 ```php
-$mysql = new React\MySQL\MysqlClient('localhost');
+$mysql = new React\Mysql\MysqlClient('localhost');
 ```
 
 This method respects PHP's `default_socket_timeout` setting (default 60s)
@@ -150,7 +150,7 @@ successful authentication. You can explicitly pass a custom timeout value
 in seconds (or use a negative number to not apply a timeout) like this:
 
 ```php
-$mysql = new React\MySQL\MysqlClient('localhost?timeout=0.5');
+$mysql = new React\Mysql\MysqlClient('localhost?timeout=0.5');
 ```
 
 By default, idle connections will be held open for 1ms (0.001s) when not
@@ -163,7 +163,7 @@ pass a custom idle timeout value in seconds (or use a negative number to
 not apply a timeout) like this:
 
 ```php
-$mysql = new React\MySQL\MysqlClient('localhost?idle=10.0');
+$mysql = new React\Mysql\MysqlClient('localhost?idle=10.0');
 ```
 
 By default, the connection provides full UTF-8 support (using the
@@ -172,7 +172,7 @@ applications nowadays, but for legacy reasons you can change this to use
 a different ASCII-compatible charset encoding like this:
 
 ```php
-$mysql = new React\MySQL\MysqlClient('localhost?charset=utf8mb4');
+$mysql = new React\Mysql\MysqlClient('localhost?charset=utf8mb4');
 ```
 
 If you need custom connector settings (DNS resolution, TLS parameters, timeouts,
@@ -191,7 +191,7 @@ $connector = new React\Socket\Connector([
     )
 ]);
 
-$mysql = new React\MySQL\MysqlClient('user:secret@localhost:3306/database', $connector);
+$mysql = new React\Mysql\MysqlClient('user:secret@localhost:3306/database', $connector);
 ```
 
 This class takes an optional `LoopInterface|null $loop` parameter that can be used to
@@ -225,7 +225,7 @@ unknown or known to be too large to fit into memory, you should use the
 [`queryStream()`](#querystream) method instead.
 
 ```php
-$mysql->query($query)->then(function (React\MySQL\MysqlResult $command) {
+$mysql->query($query)->then(function (React\Mysql\MysqlResult $command) {
     if (isset($command->resultRows)) {
         // this is a response to a SELECT etc. with some rows (0+)
         print_r($command->resultFields);

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     },
     "autoload": {
         "psr-4": {
-            "React\\MySQL\\": "src/"
+            "React\\Mysql\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "React\\Tests\\MySQL\\": "tests/"
+            "React\\Tests\\Mysql\\": "tests/"
         }
     }
 }

--- a/examples/01-query.php
+++ b/examples/01-query.php
@@ -5,10 +5,10 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$mysql = new React\MySQL\MysqlClient(getenv('MYSQL_URI') ?: 'test:test@localhost/test');
+$mysql = new React\Mysql\MysqlClient(getenv('MYSQL_URI') ?: 'test:test@localhost/test');
 
 $query = isset($argv[1]) ? $argv[1] : 'select * from book';
-$mysql->query($query)->then(function (React\MySQL\MysqlResult $command) {
+$mysql->query($query)->then(function (React\Mysql\MysqlResult $command) {
     if (isset($command->resultRows)) {
         // this is a response to a SELECT etc. with some rows (0+)
         print_r($command->resultFields);

--- a/examples/02-query-stream.php
+++ b/examples/02-query-stream.php
@@ -5,7 +5,7 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$mysql = new React\MySQL\MysqlClient(getenv('MYSQL_URI') ?: 'test:test@localhost/test');
+$mysql = new React\Mysql\MysqlClient(getenv('MYSQL_URI') ?: 'test:test@localhost/test');
 
 $query = isset($argv[1]) ? $argv[1] : 'select * from book';
 $stream = $mysql->queryStream($query);

--- a/examples/11-interactive.php
+++ b/examples/11-interactive.php
@@ -5,7 +5,7 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$mysql = new React\MySQL\MysqlClient(getenv('MYSQL_URI') ?: 'test:test@localhost/test');
+$mysql = new React\Mysql\MysqlClient(getenv('MYSQL_URI') ?: 'test:test@localhost/test');
 
 // open a STDIN stream to read keyboard input (not supported on Windows)
 $stdin = new React\Stream\ReadableResourceStream(STDIN);
@@ -25,7 +25,7 @@ $stdin->on('data', function ($line) use ($mysql) {
     }
 
     $time = microtime(true);
-    $mysql->query($query)->then(function (React\MySQL\MysqlResult $command) use ($time) {
+    $mysql->query($query)->then(function (React\Mysql\MysqlResult $command) use ($time) {
         if (isset($command->resultRows)) {
             // this is a response to a SELECT etc. with some rows (0+)
             echo implode("\t", array_column($command->resultFields, 'name')) . PHP_EOL;

--- a/examples/12-slow-stream.php
+++ b/examples/12-slow-stream.php
@@ -7,7 +7,7 @@ use React\EventLoop\Loop;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$mysql = new React\MySQL\MysqlClient(getenv('MYSQL_URI') ?: 'test:test@localhost/test');
+$mysql = new React\Mysql\MysqlClient(getenv('MYSQL_URI') ?: 'test:test@localhost/test');
 
 $query = isset($argv[1]) ? $argv[1] : 'select * from book';
 $stream = $mysql->queryStream($query);
@@ -17,7 +17,7 @@ $ref->setAccessible(true);
 $promise = $ref->getValue($mysql);
 assert($promise instanceof React\Promise\PromiseInterface);
 
-$promise->then(function (React\MySQL\Io\Connection $connection) {
+$promise->then(function (React\Mysql\Io\Connection $connection) {
     // The protocol parser reads rather large chunks from the underlying connection
     // and as such can yield multiple (dozens to hundreds) rows from a single data
     // chunk. We try to artificially limit the stream chunk size here to try to

--- a/src/Commands/AbstractCommand.php
+++ b/src/Commands/AbstractCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace React\MySQL\Commands;
+namespace React\Mysql\Commands;
 
 use Evenement\EventEmitter;
 

--- a/src/Commands/AuthenticateCommand.php
+++ b/src/Commands/AuthenticateCommand.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace React\MySQL\Commands;
+namespace React\Mysql\Commands;
 
-use React\MySQL\Io\Buffer;
-use React\MySQL\Io\Constants;
+use React\Mysql\Io\Buffer;
+use React\Mysql\Io\Constants;
 
 /**
  * @internal
@@ -31,7 +31,7 @@ class AuthenticateCommand extends AbstractCommand
      *
      * @var array<string,int>
      * @see self::$charsetNumber
-     * @see \React\MySQL\Io\Query::$escapeChars
+     * @see \React\Mysql\Io\Query::$escapeChars
      */
     private static $charsetMap = [
         'latin1' => 8,

--- a/src/Commands/CommandInterface.php
+++ b/src/Commands/CommandInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace React\MySQL\Commands;
+namespace React\Mysql\Commands;
 
 use Evenement\EventEmitterInterface;
 

--- a/src/Commands/PingCommand.php
+++ b/src/Commands/PingCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace React\MySQL\Commands;
+namespace React\Mysql\Commands;
 
 /**
  * @internal

--- a/src/Commands/QueryCommand.php
+++ b/src/Commands/QueryCommand.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace React\MySQL\Commands;
+namespace React\Mysql\Commands;
 
-use React\MySQL\Io\Query;
+use React\Mysql\Io\Query;
 
 /**
  * @internal

--- a/src/Commands/QuitCommand.php
+++ b/src/Commands/QuitCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace React\MySQL\Commands;
+namespace React\Mysql\Commands;
 
 /**
  * @internal

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace React\MySQL;
+namespace React\Mysql;
 
 class Exception extends \Exception
 {

--- a/src/Io/Buffer.php
+++ b/src/Io/Buffer.php
@@ -1,5 +1,5 @@
 <?php
-namespace React\MySQL\Io;
+namespace React\Mysql\Io;
 
 /**
  * @internal

--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace React\MySQL\Io;
+namespace React\Mysql\Io;
 
 use Evenement\EventEmitter;
-use React\MySQL\Commands\CommandInterface;
-use React\MySQL\Commands\PingCommand;
-use React\MySQL\Commands\QueryCommand;
-use React\MySQL\Commands\QuitCommand;
-use React\MySQL\Exception;
-use React\MySQL\MysqlResult;
+use React\Mysql\Commands\CommandInterface;
+use React\Mysql\Commands\PingCommand;
+use React\Mysql\Commands\QueryCommand;
+use React\Mysql\Commands\QuitCommand;
+use React\Mysql\Exception;
+use React\Mysql\MysqlResult;
 use React\Promise\Deferred;
 use React\Promise\Promise;
 use React\Socket\ConnectionInterface as SocketConnectionInterface;
 
 /**
  * @internal
- * @see \React\MySQL\MysqlClient
+ * @see \React\Mysql\MysqlClient
  */
 class Connection extends EventEmitter
 {

--- a/src/Io/Constants.php
+++ b/src/Io/Constants.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace React\MySQL\Io;
+namespace React\Mysql\Io;
 
 /**
  * @internal

--- a/src/Io/Executor.php
+++ b/src/Io/Executor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace React\MySQL\Io;
+namespace React\Mysql\Io;
 
 use Evenement\EventEmitter;
 

--- a/src/Io/Factory.php
+++ b/src/Io/Factory.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace React\MySQL\Io;
+namespace React\Mysql\Io;
 
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
-use React\MySQL\Commands\AuthenticateCommand;
-use React\MySQL\Exception;
+use React\Mysql\Commands\AuthenticateCommand;
+use React\Mysql\Exception;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use React\Promise\Timer\TimeoutException;
@@ -15,7 +15,7 @@ use React\Socket\ConnectionInterface as SocketConnectionInterface;
 
 /**
  * @internal
- * @see \React\MySQL\MysqlClient
+ * @see \React\Mysql\MysqlClient
  */
 class Factory
 {
@@ -29,7 +29,7 @@ class Factory
      * The `Factory` is responsible for creating an internal `Connection` instance.
      *
      * ```php
-     * $factory = new React\MySQL\Io\Factory();
+     * $factory = new React\Mysql\Io\Factory();
      * ```
      *
      * This class takes an optional `LoopInterface|null $loop` parameter that can be used to
@@ -54,7 +54,7 @@ class Factory
      *     ]
      * ]);
      *
-     * $factory = new React\MySQL\Factory(null, $connector);
+     * $factory = new React\Mysql\Factory(null, $connector);
      * ```
      *
      * @param ?LoopInterface $loop

--- a/src/Io/Parser.php
+++ b/src/Io/Parser.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace React\MySQL\Io;
+namespace React\Mysql\Io;
 
-use React\MySQL\Commands\AuthenticateCommand;
-use React\MySQL\Commands\QueryCommand;
-use React\MySQL\Commands\QuitCommand;
-use React\MySQL\Exception as MysqlException;
+use React\Mysql\Commands\AuthenticateCommand;
+use React\Mysql\Commands\QueryCommand;
+use React\Mysql\Commands\QuitCommand;
+use React\Mysql\Exception as MysqlException;
 use React\Stream\DuplexStreamInterface;
 
 /**
@@ -46,7 +46,7 @@ class Parser
      * next command from the `Executor` queue. If no command is outstanding,
      * this will be reset to the `null` state.
      *
-     * @var \React\MySQL\Commands\AbstractCommand|null
+     * @var \React\Mysql\Commands\AbstractCommand|null
      */
     protected $currCommand;
 

--- a/src/Io/Query.php
+++ b/src/Io/Query.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace React\MySQL\Io;
+namespace React\Mysql\Io;
 
 /**
  * @internal
@@ -25,7 +25,7 @@ class Query
      * as long as this class is only used internally for the `query()` method.
      *
      * @var array<string,string>
-     * @see \React\MySQL\Commands\AuthenticateCommand::$charsetMap
+     * @see \React\Mysql\Commands\AuthenticateCommand::$charsetMap
      */
     private $escapeChars = [
             //"\x00"   => "\\0",

--- a/src/Io/QueryStream.php
+++ b/src/Io/QueryStream.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace React\MySQL\Io;
+namespace React\Mysql\Io;
 
 use Evenement\EventEmitter;
-use React\MySQL\Commands\QueryCommand;
+use React\Mysql\Commands\QueryCommand;
 use React\Socket\ConnectionInterface;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\Util;

--- a/src/MysqlClient.php
+++ b/src/MysqlClient.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace React\MySQL;
+namespace React\Mysql;
 
 use Evenement\EventEmitter;
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
-use React\MySQL\Io\Connection;
-use React\MySQL\Io\Factory;
+use React\Mysql\Io\Connection;
+use React\Mysql\Io\Factory;
 use React\Stream\ReadableStreamInterface;
 use React\Socket\ConnectorInterface;
 
@@ -171,7 +171,7 @@ class MysqlClient extends EventEmitter
      * [`queryStream()`](#querystream) method instead.
      *
      * ```php
-     * $mysql->query($query)->then(function (React\MySQL\MysqlResult $command) {
+     * $mysql->query($query)->then(function (React\Mysql\MysqlResult $command) {
      *     if (isset($command->resultRows)) {
      *         // this is a response to a SELECT etc. with some rows (0+)
      *         print_r($command->resultFields);

--- a/src/MysqlResult.php
+++ b/src/MysqlResult.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace React\MySQL;
+namespace React\Mysql;
 
 class MysqlResult
 {

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace React\Tests\MySQL;
+namespace React\Tests\Mysql;
 
 use PHPUnit\Framework\TestCase;
 use React\EventLoop\LoopInterface;
-use React\MySQL\Io\Connection;
-use React\MySQL\Io\Factory;
+use React\Mysql\Io\Connection;
+use React\Mysql\Io\Factory;
 
 class BaseTestCase extends TestCase
 {

--- a/tests/Commands/AuthenticateCommandTest.php
+++ b/tests/Commands/AuthenticateCommandTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace React\Tests\MySQL\Commands;
+namespace React\Tests\Mysql\Commands;
 
 use PHPUnit\Framework\TestCase;
-use React\MySQL\Commands\AuthenticateCommand;
+use React\Mysql\Commands\AuthenticateCommand;
 
 class AuthenticateCommandTest extends TestCase
 {

--- a/tests/Io/BufferTest.php
+++ b/tests/Io/BufferTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace React\Tests\MySQL\Io;
+namespace React\Tests\Mysql\Io;
 
-use React\MySQL\Io\Buffer;
-use React\Tests\MySQL\BaseTestCase;
+use React\Mysql\Io\Buffer;
+use React\Tests\Mysql\BaseTestCase;
 
 class BufferTest extends BaseTestCase
 {

--- a/tests/Io/ConnectionTest.php
+++ b/tests/Io/ConnectionTest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace React\Tests\MySQL\Io;
+namespace React\Tests\Mysql\Io;
 
-use React\MySQL\Io\Connection;
-use React\Tests\MySQL\BaseTestCase;
+use React\Mysql\Io\Connection;
+use React\Tests\Mysql\BaseTestCase;
 
 class ConnectionTest extends BaseTestCase
 {
     public function testQuitWillEnqueueOneCommand()
     {
         $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
-        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(['enqueue'])->getMock();
+        $executor = $this->getMockBuilder('React\Mysql\Io\Executor')->setMethods(['enqueue'])->getMock();
         $executor->expects($this->once())->method('enqueue')->willReturnArgument(0);
 
         $conn = new Connection($stream, $executor);
@@ -20,7 +20,7 @@ class ConnectionTest extends BaseTestCase
     public function testQueryAfterQuitRejectsImmediately()
     {
         $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
-        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(['enqueue'])->getMock();
+        $executor = $this->getMockBuilder('React\Mysql\Io\Executor')->setMethods(['enqueue'])->getMock();
         $executor->expects($this->once())->method('enqueue')->willReturnArgument(0);
 
         $conn = new Connection($stream, $executor);
@@ -43,7 +43,7 @@ class ConnectionTest extends BaseTestCase
     public function testQueryAfterCloseRejectsImmediately()
     {
         $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
-        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(['enqueue'])->getMock();
+        $executor = $this->getMockBuilder('React\Mysql\Io\Executor')->setMethods(['enqueue'])->getMock();
         $executor->expects($this->never())->method('enqueue');
 
         $conn = new Connection($stream, $executor);
@@ -66,7 +66,7 @@ class ConnectionTest extends BaseTestCase
     public function testQueryStreamAfterQuitThrows()
     {
         $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
-        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(['enqueue'])->getMock();
+        $executor = $this->getMockBuilder('React\Mysql\Io\Executor')->setMethods(['enqueue'])->getMock();
         $executor->expects($this->once())->method('enqueue')->willReturnArgument(0);
 
         $conn = new Connection($stream, $executor);
@@ -83,7 +83,7 @@ class ConnectionTest extends BaseTestCase
     public function testPingAfterQuitRejectsImmediately()
     {
         $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
-        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(['enqueue'])->getMock();
+        $executor = $this->getMockBuilder('React\Mysql\Io\Executor')->setMethods(['enqueue'])->getMock();
         $executor->expects($this->once())->method('enqueue')->willReturnArgument(0);
 
         $conn = new Connection($stream, $executor);
@@ -106,7 +106,7 @@ class ConnectionTest extends BaseTestCase
     public function testQuitAfterQuitRejectsImmediately()
     {
         $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
-        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(['enqueue'])->getMock();
+        $executor = $this->getMockBuilder('React\Mysql\Io\Executor')->setMethods(['enqueue'])->getMock();
         $executor->expects($this->once())->method('enqueue')->willReturnArgument(0);
 
         $conn = new Connection($stream, $executor);
@@ -137,7 +137,7 @@ class ConnectionTest extends BaseTestCase
                 return true;
             }))
         );
-        $executor = $this->getMockBuilder('React\MySQL\Io\Executor')->setMethods(['enqueue'])->getMock();
+        $executor = $this->getMockBuilder('React\Mysql\Io\Executor')->setMethods(['enqueue'])->getMock();
         $executor->expects($this->never())->method('enqueue');
 
         $conn = new Connection($stream, $executor);

--- a/tests/Io/FactoryTest.php
+++ b/tests/Io/FactoryTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace React\Tests\MySQL\Io;
+namespace React\Tests\Mysql\Io;
 
 use React\EventLoop\Loop;
-use React\MySQL\Io\Connection;
-use React\MySQL\Io\Factory;
+use React\Mysql\Io\Connection;
+use React\Mysql\Io\Factory;
 use React\Promise\Promise;
 use React\Socket\SocketServer;
-use React\Tests\MySQL\BaseTestCase;
+use React\Tests\Mysql\BaseTestCase;
 
 class FactoryTest extends BaseTestCase
 {

--- a/tests/Io/ParserTest.php
+++ b/tests/Io/ParserTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace React\Tests\MySQL\Io;
+namespace React\Tests\Mysql\Io;
 
-use React\MySQL\Commands\QueryCommand;
-use React\MySQL\Exception;
-use React\MySQL\Io\Executor;
-use React\MySQL\Io\Parser;
+use React\Mysql\Commands\QueryCommand;
+use React\Mysql\Exception;
+use React\Mysql\Io\Executor;
+use React\Mysql\Io\Parser;
 use React\Stream\CompositeStream;
 use React\Stream\ThroughStream;
-use React\Tests\MySQL\BaseTestCase;
+use React\Tests\Mysql\BaseTestCase;
 
 class ParserTest extends BaseTestCase
 {

--- a/tests/Io/QueryStreamTest.php
+++ b/tests/Io/QueryStreamTest.php
@@ -1,8 +1,10 @@
 <?php
 
-use React\MySQL\Commands\QueryCommand;
-use React\MySQL\Io\QueryStream;
-use React\Tests\MySQL\BaseTestCase;
+namespace React\Tests\Mysql\Io;
+
+use React\Mysql\Commands\QueryCommand;
+use React\Mysql\Io\QueryStream;
+use React\Tests\Mysql\BaseTestCase;
 
 class QueryStreamTest extends BaseTestCase
 {
@@ -63,7 +65,7 @@ class QueryStreamTest extends BaseTestCase
         $stream->on('error', $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException')));
         $stream->on('close', $this->expectCallableOnce());
 
-        $command->emit('error', [new RuntimeException()]);
+        $command->emit('error', [new \RuntimeException()]);
     }
 
     public function testPauseForwardsToConnectionAfterResultStarted()

--- a/tests/Io/QueryTest.php
+++ b/tests/Io/QueryTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace React\Tests\MySQL\Io;
+namespace React\Tests\Mysql\Io;
 
 use PHPUnit\Framework\TestCase;
-use React\MySQL\Io\Query;
+use React\Mysql\Io\Query;
 
 class QueryTest extends TestCase
 {

--- a/tests/MysqlClientTest.php
+++ b/tests/MysqlClientTest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace React\Tests\MySQL\Io;
+namespace React\Tests\Mysql\Io;
 
-use React\MySQL\Io\Connection;
-use React\MySQL\MysqlClient;
-use React\MySQL\MysqlResult;
+use React\Mysql\Io\Connection;
+use React\Mysql\MysqlClient;
+use React\Mysql\MysqlResult;
 use React\Promise\Deferred;
 use React\Promise\Promise;
 use React\Promise\PromiseInterface;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\ThroughStream;
-use React\Tests\MySQL\BaseTestCase;
+use React\Tests\Mysql\BaseTestCase;
 
 class MysqlClientTest extends BaseTestCase
 {
@@ -71,7 +71,7 @@ class MysqlClientTest extends BaseTestCase
     public function testPingWillNotCloseConnectionWhenPendingConnectionFails()
     {
         $deferred = new Deferred();
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -93,10 +93,10 @@ class MysqlClientTest extends BaseTestCase
 
     public function testPingWillNotCloseConnectionWhenUnderlyingConnectionCloses()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->setMethods(['ping', 'close'])->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->setMethods(['ping', 'close'])->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -117,10 +117,10 @@ class MysqlClientTest extends BaseTestCase
 
     public function testPingWillCancelTimerWithoutClosingConnectionWhenUnderlyingConnectionCloses()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->setMethods(['ping', 'close'])->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->setMethods(['ping', 'close'])->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
@@ -144,10 +144,10 @@ class MysqlClientTest extends BaseTestCase
 
     public function testPingWillNotForwardErrorFromUnderlyingConnection()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->setMethods(['ping'])->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->setMethods(['ping'])->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -167,12 +167,12 @@ class MysqlClientTest extends BaseTestCase
 
     public function testPingFollowedByIdleTimerWillQuitUnderlyingConnection()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->setMethods(['ping', 'quit', 'close'])->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->setMethods(['ping', 'quit', 'close'])->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('quit')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->never())->method('close');
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $timeout = null;
@@ -199,12 +199,12 @@ class MysqlClientTest extends BaseTestCase
 
     public function testPingFollowedByIdleTimerWillCloseUnderlyingConnectionWhenQuitFails()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->setMethods(['ping', 'quit', 'close'])->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->setMethods(['ping', 'quit', 'close'])->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('quit')->willReturn(\React\Promise\reject(new \RuntimeException()));
         $base->expects($this->once())->method('close');
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $timeout = null;
@@ -231,12 +231,12 @@ class MysqlClientTest extends BaseTestCase
 
     public function testPingAfterIdleTimerWillCloseUnderlyingConnectionBeforeCreatingSecondConnection()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->setMethods(['ping', 'quit', 'close'])->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->setMethods(['ping', 'quit', 'close'])->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('quit')->willReturn(new Promise(function () { }));
         $base->expects($this->once())->method('close');
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->exactly(2))->method('createConnection')->willReturnOnConsecutiveCalls(
             \React\Promise\resolve($base),
             new Promise(function () { })
@@ -270,7 +270,7 @@ class MysqlClientTest extends BaseTestCase
     public function testQueryReturnsPendingPromiseAndWillNotStartTimerWhenConnectionIsPending()
     {
         $deferred = new Deferred();
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -290,10 +290,10 @@ class MysqlClientTest extends BaseTestCase
 
     public function testQueryWillQueryUnderlyingConnectionWhenResolved()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('query')->with('SELECT 1')->willReturn(new Promise(function () { }));
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -310,10 +310,10 @@ class MysqlClientTest extends BaseTestCase
     {
         $result = new MysqlResult();
 
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('query')->with('SELECT 1')->willReturn(\React\Promise\resolve($result));
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -333,10 +333,10 @@ class MysqlClientTest extends BaseTestCase
     {
         $result = new MysqlResult();
 
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('query')->with('SELECT 1')->willReturn(\React\Promise\resolve($result));
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -356,10 +356,10 @@ class MysqlClientTest extends BaseTestCase
     {
         $result = new MysqlResult();
 
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('query')->with('SELECT 1')->willReturn(\React\Promise\resolve($result));
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -380,11 +380,11 @@ class MysqlClientTest extends BaseTestCase
         $result = new MysqlResult();
         $deferred = new Deferred();
 
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('query')->with('SELECT 1')->willReturn($deferred->promise());
         $base->expects($this->once())->method('ping')->willReturn(new Promise(function () { }));
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -406,11 +406,11 @@ class MysqlClientTest extends BaseTestCase
 
     public function testQueryAfterPingWillCancelTimerAgainWhenPingFromUnderlyingConnectionResolved()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('query')->with('SELECT 1')->willReturn(new Promise(function () { }));
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
@@ -432,10 +432,10 @@ class MysqlClientTest extends BaseTestCase
     {
         $error = new \RuntimeException();
 
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('query')->with('SELECT 1')->willReturn(\React\Promise\reject($error));
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -454,7 +454,7 @@ class MysqlClientTest extends BaseTestCase
     public function testQueryWillRejectWithoutStartingTimerWhenUnderlyingConnectionRejects()
     {
         $deferred = new Deferred();
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -475,7 +475,7 @@ class MysqlClientTest extends BaseTestCase
     public function testQueryStreamReturnsReadableStreamWhenConnectionIsPending()
     {
         $promise = new Promise(function () { });
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn($promise);
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -494,10 +494,10 @@ class MysqlClientTest extends BaseTestCase
     public function testQueryStreamWillReturnStreamFromUnderlyingConnectionWithoutStartingTimerWhenResolved()
     {
         $stream = new ThroughStream();
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('queryStream')->with('SELECT 1')->willReturn($stream);
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -520,10 +520,10 @@ class MysqlClientTest extends BaseTestCase
     public function testQueryStreamWillReturnStreamFromUnderlyingConnectionAndStartTimerWhenResolvedAndClosed()
     {
         $stream = new ThroughStream();
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('queryStream')->with('SELECT 1')->willReturn($stream);
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -549,7 +549,7 @@ class MysqlClientTest extends BaseTestCase
     public function testQueryStreamWillCloseStreamWithErrorWhenUnderlyingConnectionRejects()
     {
         $deferred = new Deferred();
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -572,7 +572,7 @@ class MysqlClientTest extends BaseTestCase
     public function testPingReturnsPendingPromiseWhenConnectionIsPending()
     {
         $promise = new Promise(function () { });
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn($promise);
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -590,10 +590,10 @@ class MysqlClientTest extends BaseTestCase
 
     public function testPingWillPingUnderlyingConnectionWhenResolved()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(new Promise(function () { }));
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -611,7 +611,7 @@ class MysqlClientTest extends BaseTestCase
         $error = new \RuntimeException();
         $deferred = new Deferred();
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -631,7 +631,7 @@ class MysqlClientTest extends BaseTestCase
     {
         $error = new \RuntimeException();
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->exactly(2))->method('createConnection')->willReturn(\React\Promise\reject($error));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -647,10 +647,10 @@ class MysqlClientTest extends BaseTestCase
 
     public function testPingWillResolveAndStartTimerWhenPingFromUnderlyingConnectionResolves()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -670,10 +670,10 @@ class MysqlClientTest extends BaseTestCase
     {
         $error = new \RuntimeException();
 
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\reject($error));
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -693,14 +693,14 @@ class MysqlClientTest extends BaseTestCase
     {
         $error = new \RuntimeException();
 
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->setMethods(['ping', 'close'])->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->setMethods(['ping', 'close'])->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturnCallback(function () use ($base, $error) {
             $base->emit('close');
             return \React\Promise\reject($error);
         });
         $base->expects($this->never())->method('close');
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -718,7 +718,7 @@ class MysqlClientTest extends BaseTestCase
 
     public function testQuitResolvesAndEmitsCloseImmediatelyWhenConnectionIsNotAlreadyPending()
     {
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->never())->method('createConnection');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -740,7 +740,7 @@ class MysqlClientTest extends BaseTestCase
     public function testQuitAfterPingReturnsPendingPromiseWhenConnectionIsPending()
     {
         $promise = new Promise(function () { });
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn($promise);
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -759,11 +759,11 @@ class MysqlClientTest extends BaseTestCase
 
     public function testQuitAfterPingWillQuitUnderlyingConnectionWhenResolved()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('quit')->willReturn(new Promise(function () { }));
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -779,11 +779,11 @@ class MysqlClientTest extends BaseTestCase
 
     public function testQuitAfterPingResolvesAndEmitsCloseWhenUnderlyingConnectionQuits()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('quit')->willReturn(\React\Promise\resolve(null));
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -805,11 +805,11 @@ class MysqlClientTest extends BaseTestCase
     public function testQuitAfterPingRejectsAndEmitsCloseWhenUnderlyingConnectionFailsToQuit()
     {
         $error = new \RuntimeException();
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('quit')->willReturn(\React\Promise\reject($error));
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -830,7 +830,7 @@ class MysqlClientTest extends BaseTestCase
 
     public function testCloseEmitsCloseImmediatelyWhenConnectionIsNotAlreadyPending()
     {
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->never())->method('createConnection');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -849,7 +849,7 @@ class MysqlClientTest extends BaseTestCase
     public function testCloseAfterPingCancelsPendingConnection()
     {
         $deferred = new Deferred($this->expectCallableOnce());
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -865,11 +865,11 @@ class MysqlClientTest extends BaseTestCase
 
     public function testCloseTwiceAfterPingWillCloseUnderlyingConnectionWhenResolved()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('close');
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -890,7 +890,7 @@ class MysqlClientTest extends BaseTestCase
             throw new \RuntimeException();
         });
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn($promise);
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -912,10 +912,10 @@ class MysqlClientTest extends BaseTestCase
 
     public function testCloseAfterPingWillCancelTimerWhenPingFromUnderlyingConnectionResolves()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
@@ -935,13 +935,13 @@ class MysqlClientTest extends BaseTestCase
 
     public function testCloseAfterPingHasResolvedWillCloseUnderlyingConnectionWithoutTryingToCancelConnection()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->setMethods(['ping', 'close'])->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->setMethods(['ping', 'close'])->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('close')->willReturnCallback(function () use ($base) {
             $base->emit('close');
         });
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -958,12 +958,12 @@ class MysqlClientTest extends BaseTestCase
 
     public function testCloseAfterQuitAfterPingWillCloseUnderlyingConnectionWhenQuitIsStillPending()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('quit')->willReturn(new Promise(function () { }));
         $base->expects($this->once())->method('close');
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -980,12 +980,12 @@ class MysqlClientTest extends BaseTestCase
 
     public function testCloseAfterPingAfterIdleTimeoutWillCloseUnderlyingConnectionWhenQuitIsStillPending()
     {
-        $base = $this->getMockBuilder('React\MySQL\Io\Connection')->disableOriginalConstructor()->getMock();
+        $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $base->expects($this->once())->method('ping')->willReturn(\React\Promise\resolve(null));
         $base->expects($this->once())->method('quit')->willReturn(new Promise(function () { }));
         $base->expects($this->once())->method('close');
 
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
 
         $timeout = null;
@@ -1013,7 +1013,7 @@ class MysqlClientTest extends BaseTestCase
     public function testCloseTwiceAfterPingEmitsCloseEventOnceWhenConnectionIsPending()
     {
         $promise = new Promise(function () { });
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn($promise);
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -1033,7 +1033,7 @@ class MysqlClientTest extends BaseTestCase
 
     public function testQueryReturnsRejectedPromiseAfterConnectionIsClosed()
     {
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->never())->method('createConnection');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -1052,7 +1052,7 @@ class MysqlClientTest extends BaseTestCase
 
     public function testQueryStreamThrowsAfterConnectionIsClosed()
     {
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->never())->method('createConnection');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -1064,13 +1064,13 @@ class MysqlClientTest extends BaseTestCase
 
         $connection->close();
 
-        $this->setExpectedException('React\MySQL\Exception');
+        $this->setExpectedException('React\Mysql\Exception');
         $connection->queryStream('SELECT 1');
     }
 
     public function testPingReturnsRejectedPromiseAfterConnectionIsClosed()
     {
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->never())->method('createConnection');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -1089,7 +1089,7 @@ class MysqlClientTest extends BaseTestCase
 
     public function testQuitReturnsRejectedPromiseAfterConnectionIsClosed()
     {
-        $factory = $this->getMockBuilder('React\MySQL\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->never())->method('createConnection');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 

--- a/tests/NoResultQueryTest.php
+++ b/tests/NoResultQueryTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace React\Tests\MySQL;
+namespace React\Tests\Mysql;
 
 use React\EventLoop\Loop;
-use React\MySQL\MysqlClient;
-use React\MySQL\MysqlResult;
+use React\Mysql\MysqlClient;
+use React\Mysql\MysqlResult;
 
 class NoResultQueryTest extends BaseTestCase
 {

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace React\Tests\MySQL;
+namespace React\Tests\Mysql;
 
 use React\EventLoop\Loop;
-use React\MySQL\Io\Constants;
-use React\MySQL\MysqlClient;
-use React\MySQL\MysqlResult;
+use React\Mysql\Io\Constants;
+use React\Mysql\MysqlClient;
+use React\Mysql\MysqlResult;
 
 class ResultQueryTest extends BaseTestCase
 {


### PR DESCRIPTION
This pull request changes the `React\MySQL` namespace to `React\Mysql` without any additional code adjustments.

Both options are valid when it comes to PSR-4. The specification describes the use of alphabetic characters like this:

> Alphabetic characters in the fully qualified class name MAY be any combination of lower case and upper case.

Changing the namespace to `React\Mysql` aligns with recent changes made in #186 and #187, where we added a `Mysql` prefix to name the `MysqlClient` and `MysqlResult`. This means my suggested PR improves the consistency when it comes to naming our namespace, classes, and variables.

Considering that `v0.7.x` already includes BC-Breaks from #186 and #187, it could be a perfect time to introduce this additional BC-Break as well.

I'm interested in your thoughts on this :+1: 