### PR TITLE
Consistently emit close event after quit even if server rejects

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,11 @@ $mysql->query('CREATE TABLE test ...');
 $mysql->quit();
 ```
 
+This method will gracefully close the connection to the MySQL database
+server once all outstanding commands are completed. See also
+[`close()`](#close) if you want to force-close the connection without
+waiting for any commands to complete instead.
+
 #### close()
 
 The `close(): void` method can be used to

--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -135,17 +135,16 @@ class Connection extends EventEmitter
     public function quit()
     {
         return new Promise(function ($resolve, $reject) {
-            $this->_doCommand(new QuitCommand())
-                ->on('error', function ($reason) use ($reject) {
-                    $reject($reason);
-                })
-                ->on('success', function () use ($resolve) {
-                    $this->state = self::STATE_CLOSED;
-                    $this->emit('end', [$this]);
-                    $this->emit('close', [$this]);
-                    $resolve(null);
-                });
+            $command = $this->_doCommand(new QuitCommand());
             $this->state = self::STATE_CLOSING;
+            $command->on('success', function () use ($resolve) {
+                $resolve(null);
+                $this->close();
+            });
+            $command->on('error', function ($reason) use ($reject) {
+                $reject($reason);
+                $this->close();
+            });
         });
     }
 

--- a/tests/NoResultQueryTest.php
+++ b/tests/NoResultQueryTest.php
@@ -133,13 +133,34 @@ CREATE TABLE IF NOT EXISTS `book` (
         Loop::run();
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    public function testPingAndQuitWillFulfillPingBeforeQuitBeforeCloseEvent()
+    {
+        $this->expectOutputString('ping.quit.close.');
+
+        $uri = $this->getConnectionString();
+        $connection = new MysqlClient($uri);
+
+        $connection->on('close', function () {
+            echo 'close.';
+        });
+
+        $connection->ping()->then(function () {
+            echo 'ping.';
+        });
+
+        $connection->quit()->then(function () {
+            echo 'quit.';
+        });
+
+        Loop::run();
+    }
+
     public function testPingWithValidAuthWillRunUntilIdleTimerAfterPingEvenWithoutQuit()
     {
         $uri = $this->getConnectionString();
         $connection = new MysqlClient($uri);
+
+        $connection->on('close', $this->expectCallableNever());
 
         $connection->ping();
 


### PR DESCRIPTION
This changeset ensures we consistently emit a `close` event after a `quit()` call even if the server rejects. This is more of an edge case I've encountered while working on support for multiple connections as discussed in #175, so I figured it makes sense to properly close the connection in case the server does not already do this as usually expected.

Follow-up PRs will build on top of this to use dedicated `open` and `close` events as discussed in #147 and support multiple connections as discussed in #175.

Builds on top of #187 