### PR TITLE
Refactor to move command queue to `MysqlClient` and connection logic to `Connection` class

### DIFF
--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -40,6 +40,9 @@ class Connection extends EventEmitter
      */
     private $stream;
 
+    /** @var Parser */
+    private $parser;
+
     /** @var LoopInterface */
     private $loop;
 
@@ -57,13 +60,15 @@ class Connection extends EventEmitter
      *
      * @param SocketConnectionInterface $stream
      * @param Executor                  $executor
+     * @param Parser                    $parser
      * @param LoopInterface             $loop
      * @param ?float                    $idlePeriod
      */
-    public function __construct(SocketConnectionInterface $stream, Executor $executor, LoopInterface $loop, $idlePeriod)
+    public function __construct(SocketConnectionInterface $stream, Executor $executor, Parser $parser, LoopInterface $loop, $idlePeriod)
     {
         $this->stream   = $stream;
         $this->executor = $executor;
+        $this->parser   = $parser;
 
         $this->loop = $loop;
         if ($idlePeriod !== null) {
@@ -72,6 +77,17 @@ class Connection extends EventEmitter
 
         $stream->on('error', [$this, 'handleConnectionError']);
         $stream->on('close', [$this, 'handleConnectionClosed']);
+    }
+
+    /**
+     * busy executing some command such as query or ping
+     *
+     * @return bool
+     * @throws void
+     */
+    public function isBusy()
+    {
+        return $this->parser->isBusy() || !$this->executor->isIdle();
     }
 
     /**

--- a/src/Io/Factory.php
+++ b/src/Io/Factory.php
@@ -215,7 +215,7 @@ class Factory
             $executor = new Executor();
             $parser = new Parser($stream, $executor);
 
-            $connection = new Connection($stream, $executor, $this->loop, $idlePeriod);
+            $connection = new Connection($stream, $executor, $parser, $this->loop, $idlePeriod);
             $command = $executor->enqueue($authCommand);
             $parser->start();
 

--- a/src/Io/Factory.php
+++ b/src/Io/Factory.php
@@ -210,11 +210,12 @@ class Factory
             $connecting->cancel();
         });
 
-        $connecting->then(function (SocketConnectionInterface $stream) use ($authCommand, $deferred, $uri) {
+        $idlePeriod = isset($args['idle']) ? (float) $args['idle'] : null;
+        $connecting->then(function (SocketConnectionInterface $stream) use ($authCommand, $deferred, $uri, $idlePeriod) {
             $executor = new Executor();
             $parser = new Parser($stream, $executor);
 
-            $connection = new Connection($stream, $executor);
+            $connection = new Connection($stream, $executor, $this->loop, $idlePeriod);
             $command = $executor->enqueue($authCommand);
             $parser->start();
 

--- a/src/Io/Parser.php
+++ b/src/Io/Parser.php
@@ -115,6 +115,17 @@ class Parser
         });
     }
 
+    /**
+     * busy executing some command such as query or ping
+     *
+     * @return bool
+     * @throws void
+     */
+    public function isBusy()
+    {
+        return $this->currCommand !== null;
+    }
+
     public function start()
     {
         $this->stream->on('data', [$this, 'handleData']);


### PR DESCRIPTION
This changeset includes a major refactoring to move the command queue to the `MysqlClient` and the connection logic to the `Connection` class. This is specifically done to prepare the underlying classes and APIs to add support for multiple connections (connection pooling as discussed in #175) in a follow-up PR.

This changeset includes a large number of additional test cases to ensure this works as expected and should not otherwise affect any of our public APIs in any way, as confirmed by the existing functional tests. The affected code now has 100% test coverage through additional unit tests, most of which was only covered in functional tests previously. I've tried hard to avoid introducing any unneeded changes and keep as much as possible of the given structure, considering this changeset affects a substantial part of our APIs already. A follow-up PR should clean up the test suite, reorder some of the tests and update the functional test suite to omit the functional tests when no `MYSQL_URI` is given.

I think this might very well be one of the largest refactorings in ReactPHP recently. Just for the code changes alone you're already looking at several full days of work, plus countless sessions to discuss various approaches (thanks to @SimonFrings and @yadaiio!), enjoy! Special thanks to our sponsors for making this possible! If you'd like to support this development, consider [sponsoring ReactPHP](https://github.com/sponsors/reactphp)! ❤️

Refs #175 and #147
Builds on top of #189 and #186
