### PR TITLE
Add missing namespace import in `MysqlClient`

### DIFF
--- a/src/MysqlClient.php
+++ b/src/MysqlClient.php
@@ -8,6 +8,7 @@ use React\Mysql\Io\Connection;
 use React\Mysql\Io\Factory;
 use React\Promise\Deferred;
 use React\Promise\Promise;
+use React\Promise\PromiseInterface;
 use React\Socket\ConnectorInterface;
 use React\Stream\ReadableStreamInterface;
 


### PR DESCRIPTION
Adds a missing `use` statement for the `PromiseInterface` type to `MysqlClient`. Without that change, using the API leads to type warnings:

```php
function someMethod(): PromiseInterface {
  return $this->mysql->query(...);
}
// Return value is expected to be '\React\Promise\PromiseInterface', '\React\Mysql\PromiseInterface' returned
```

![image](https://github.com/friends-of-reactphp/mysql/assets/307571/a5c0a341-2cf2-4fcd-9144-8cb7dfee51fb)
