### PR TITLE
Fix MariaDB support in `FactoryTest`

### DIFF
--- a/tests/Io/FactoryTest.php
+++ b/tests/Io/FactoryTest.php
@@ -169,13 +169,13 @@ class FactoryTest extends BaseTestCase
             $this->logicalAnd(
                 $this->isInstanceOf('RuntimeException'),
                 $this->callback(function (\RuntimeException $e) {
-                    return !!preg_match("/^Connection to mysql:\/\/[^ ]* failed during authentication: Access denied for user '.*?'@'.*?' \(using password: YES\) \(EACCES\)$/", $e->getMessage());
+                    return !!preg_match("/^Connection to mysql:\/\/[^ ]* failed during authentication: Access denied for user '.*?'@'.*?'( \(using password: YES\))? \(EACCES\)$/", $e->getMessage());
                 }),
                 $this->callback(function (\RuntimeException $e) {
                     return $e->getCode() === (defined('SOCKET_EACCES') ? SOCKET_EACCES : 13);
                 }),
                 $this->callback(function (\RuntimeException $e) {
-                    return !!preg_match("/^Access denied for user '.*?'@'.*?' \(using password: YES\)$/", $e->getPrevious()->getMessage());
+                    return !!preg_match("/^Access denied for user '.*?'@'.*?'( \(using password: YES\))?$/", $e->getPrevious()->getMessage());
                 })
             )
         ));


### PR DESCRIPTION
Apparently MariaDB does not contain the
```
 (using password: YES)
```
substring in the authentication error message.
By making that substring optional in the corresponding regex check, the tests are green for me (11.1.2-MariaDB @ Macbook Pro M1)