### PR TITLE
Support protocol packages larger than 16 MiB #47

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           coverage: xdebug
           ini-file: development
       - run: composer install
-      - run: docker run -d --name mysql --net=host -e MYSQL_RANDOM_ROOT_PASSWORD=yes -e MYSQL_DATABASE=test -e MYSQL_USER=test -e MYSQL_PASSWORD=test mysql:5
+      - run: docker run -d --name mysql --net=host -e MYSQL_RANDOM_ROOT_PASSWORD=yes -e MYSQL_DATABASE=test -e MYSQL_USER=test -e MYSQL_PASSWORD=test mysql:5 --max-allowed-packet=20M
       - run: bash tests/wait-for-mysql.sh
       - run: vendor/bin/phpunit --coverage-text
         if: ${{ matrix.php >= 7.3 }}
@@ -49,6 +49,6 @@ jobs:
         uses: docker://hhvm/hhvm:3.30-lts-latest
         with:
           args: hhvm composer.phar install
-      - run: docker run -d --name mysql --net=host -e MYSQL_RANDOM_ROOT_PASSWORD=yes -e MYSQL_DATABASE=test -e MYSQL_USER=test -e MYSQL_PASSWORD=test mysql:5
+      - run: docker run -d --name mysql --net=host -e MYSQL_RANDOM_ROOT_PASSWORD=yes -e MYSQL_DATABASE=test -e MYSQL_USER=test -e MYSQL_PASSWORD=test mysql:5 --max-allowed-packet=20M
       - run: bash tests/wait-for-mysql.sh
       - run: docker run -i --rm --workdir=/data -v "$(pwd):/data" --net=host hhvm/hhvm:3.30-lts-latest hhvm vendor/bin/phpunit

--- a/src/Io/Parser.php
+++ b/src/Io/Parser.php
@@ -103,6 +103,10 @@ class Parser
      * @var Executor
      */
     protected $executor;
+    /**
+     * Current packet for split packet paring
+     */
+    protected $packet = null;
 
     public function __construct(DuplexStreamInterface $stream, Executor $executor)
     {
@@ -165,22 +169,48 @@ class Parser
                 return;
             }
 
-            $packet = $this->buffer->readBuffer($this->pctSize);
+            if ($this->packet !== null) {
+                /**
+                 * We are in packet splitting
+                 * Append data
+                 */
+                $packet = null;
+                $this->packet->append($this->buffer->read($this->pctSize));
+                if ($this->pctSize < 0xffffff) {
+                    /**
+                     * We're done
+                     */
+                    $packet = $this->packet;
+                    $this->packet = null;
+                }
+            } else {
+                $packet = $this->buffer->readBuffer($this->pctSize);
+            }
+            /**
+             * Remember last packet size as split packets may have ended with 0 length packet.
+             */
+            $lastPctSize = $this->pctSize;
             $this->state = self::STATE_STANDBY;
             $this->pctSize = self::PACKET_SIZE_HEADER;
+            if ($this->packet === null && $packet->length() === 0xffffff && $lastPctSize > 0) {
+                /**
+                 * Start reading split packets
+                 */
+                $this->packet = $packet;
+            } elseif ($packet !== null) {
+                try {
+                    $this->parsePacket($packet);
+                } catch (\UnderflowException $e) {
+                    $this->onError(new \UnexpectedValueException('Unexpected protocol error, received malformed packet: ' . $e->getMessage(), 0, $e));
+                    $this->stream->close();
+                    return;
+                }
 
-            try {
-                $this->parsePacket($packet);
-            } catch (\UnderflowException $e) {
-                $this->onError(new \UnexpectedValueException('Unexpected protocol error, received malformed packet: ' . $e->getMessage(), 0, $e));
-                $this->stream->close();
-                return;
-            }
-
-            if ($packet->length() !== 0) {
-                $this->onError(new \UnexpectedValueException('Unexpected protocol error, received malformed packet with ' . $packet->length() . ' unknown byte(s)'));
-                $this->stream->close();
-                return;
+                if ($packet->length() !== 0) {
+                    $this->onError(new \UnexpectedValueException('Unexpected protocol error, received malformed packet with ' . $packet->length() . ' unknown byte(s)'));
+                    $this->stream->close();
+                    return;
+                }
             }
         }
     }
@@ -262,7 +292,7 @@ class Parser
                 $this->debug(sprintf("AffectedRows: %d, InsertId: %d, WarningCount:%d", $this->affectedRows, $this->insertId, $this->warningCount));
                 $this->onSuccess();
                 $this->nextRequest();
-            } elseif ($fieldCount === 0xFE) {
+            } elseif ($fieldCount === 0xFE && $packet->length() < 0xfffffe) {
                 // EOF Packet
                 $packet->skip(4); // warn, status
                 if ($this->rsState === self::RS_STATE_ROW) {
@@ -388,7 +418,35 @@ class Parser
 
     public function sendPacket($packet)
     {
-        return $this->stream->write($this->buffer->buildInt3(\strlen($packet)) . $this->buffer->buildInt1($this->seq++) . $packet);
+        /**
+         * If packet is longer than 0xffffff (16M), we should split and send many packets
+         *
+         */
+        $packet_len = \strlen($packet);
+        $this->debug('sendPacket: len: ' . $packet_len);
+
+        if ($packet_len >= 0xffffff) {
+            $this->debug('Packet split: packet_len: ' . $packet_len);
+            $ret = null;
+            while ($packet_len > 0) {
+                $part = \substr($packet, 0, 0xffffff);
+                $part_len = \strlen($part);
+                $ret = $this->stream->write($this->buffer->buildInt3($part_len) . $this->buffer->buildInt1($this->seq++) . $part);
+                $packet = \substr($packet, $part_len);
+                $packet_len = \strlen($packet);
+                // If last part was exactly 0xffffff in size, we need to send an empty packet to signal end
+                // of packet splitting.
+                if (\strlen($packet) === 0 && $part_len === 0xffffff) {
+                    $ret = $this->stream->write($this->buffer->buildInt3(0) . $this->buffer->buildInt1($this->seq++));
+                }
+            }
+            $this->debug('Packet sent');
+            return $ret;
+        }
+        /**
+         * Packet is below 16M
+         */
+        return $this->stream->write($this->buffer->buildInt3($packet_len) . $this->buffer->buildInt1($this->seq++) . $packet);
     }
 
     protected function nextRequest($isHandshake = false)


### PR DESCRIPTION
Reopened PR (https://github.com/friends-of-reactphp/mysql/pull/166)

There are currently no tests performed for this.

@SimonFrings 

Should the functionality be tested in `tests/MysqlClientTest.php` or only in `tests/Io/ParserTest.php` or in both?

We had some issues before with testing on real Mysql server as `max_allowed_packet` has to be set above 16M limit in order to test packet splitting. When default is used (16M), you cannot really send a packet of sufficient size to start packet splitting.