### PR TITLE
Fix memory leaks described in issue #179

### DIFF
--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -179,6 +179,12 @@ class Connection extends EventEmitter implements ConnectionInterface
         }
 
         $this->emit('close');
+        /**
+         * MemoryLeak: Remove all listeners from executor, so it
+         * will be removed from memory when connection
+         * is closed.
+         */
+        $this->executor->removeAllListeners();
         $this->removeAllListeners();
     }
 

--- a/src/Io/Executor.php
+++ b/src/Io/Executor.php
@@ -23,6 +23,28 @@ class Executor extends EventEmitter
 
     public function enqueue($command)
     {
+        /**
+         * MemoryLeak: Make sure removeAllListeners is called on commands,
+         * otherwise they might stay in memory for ever.
+         */
+        $command->on(
+            'error',
+            function () use ($command) {
+                $command->removeAllListeners();
+            }
+        );
+        $command->on(
+            'success',
+            function () use ($command) {
+                $command->removeAllListeners();
+            }
+        );
+        $command->on(
+            'end',
+            function () use ($command) {
+                $command->removeAllListeners();
+            }
+        );
         $this->queue->enqueue($command);
         $this->emit('new');
 


### PR DESCRIPTION
Hello,

this is a memory leak fix for 0.6.x branch.

- Executor calls `removeAllListeners()` on all commands.
- Connection will remove all listeners from `executor` when connection closes
  - Obvious memory-leak here is when `LazyConnection` opens/closes connection.

Example script:

```php
<?php

// load reactphp-mysql/vendor/autoload.php

$loop = \React\EventLoop\Loop::get();
$factory = new \React\MySQL\Factory();
$connection = $factory->createLazyConnection('localhost');
//$connection = \React\Async\await($factory->createConnection('localhost'));

$pre_memory = 0;

$loop->addPeriodicTimer(
    1,
    function () use ($connection, &$pre_memory) {
        $connection->query('SELECT \'' . str_repeat('A', 1000) . '\'')->then(
            function ($res) use (&$pre_memory) {
                echo " - query done\n";
                $cur_memory = memory_get_usage();
                $new_memory = $cur_memory - $pre_memory;
                echo " - Memory usage: " . memory_get_usage() . " new: " . $new_memory . "\n";
                $pre_memory = $cur_memory;
            },
            function ($e) {
                echo " - query error: " . $e->getMessage() . "\n";
                throw $e;
            }
        );
    }
);

$loop->run();
```