### PR TITLE
Improve PHP 8.4+ support by avoiding implicitly nullable types

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ will not have to wait for an actual underlying connection.
 
 #### __construct()
 
-The `new MysqlClient(string $uri, ConnectorInterface $connector = null, LoopInterface $loop = null)` constructor can be used to
+The `new MysqlClient(string $uri, ?ConnectorInterface $connector = null, ?LoopInterface $loop = null)` constructor can be used to
 create a new `MysqlClient` instance.
 
 The `$uri` parameter must contain the database host, optional

--- a/composer.json
+++ b/composer.json
@@ -7,14 +7,14 @@
         "php": ">=5.4.0",
         "evenement/evenement": "^3.0 || ^2.1 || ^1.1",
         "react/event-loop": "^1.2",
-        "react/promise": "^3 || ^2.7",
+        "react/promise": "^3.2 || ^2.7",
         "react/promise-stream": "^1.6",
-        "react/promise-timer": "^1.9",
-        "react/socket": "^1.12"
+        "react/promise-timer": "^1.11",
+        "react/socket": "^1.16"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
-        "react/async": "^4 || ^3 || ^2"
+        "react/async": "^4.3 || ^3 || ^2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Io/Factory.php
+++ b/src/Io/Factory.php
@@ -60,8 +60,12 @@ class Factory
      * @param ?LoopInterface $loop
      * @param ?ConnectorInterface $connector
      */
-    public function __construct(LoopInterface $loop = null, ConnectorInterface $connector = null)
+    public function __construct($loop = null, $connector = null)
     {
+        // manual type check to support legacy PHP < 7.1
+        assert($loop === null || $loop instanceof LoopInterface);
+        assert($connector === null || $connector instanceof ConnectorInterface);
+
         $this->loop = $loop ?: Loop::get();
         $this->connector = $connector ?: new Connector([], $this->loop);
     }

--- a/src/MysqlClient.php
+++ b/src/MysqlClient.php
@@ -76,12 +76,24 @@ class MysqlClient extends EventEmitter
      */
     private $quitting = false;
 
+    /**
+     * @param string $uri
+     * @param ?ConnectorInterface $connector
+     * @param ?LoopInterface $loop
+     */
     public function __construct(
         #[\SensitiveParameter]
         $uri,
-        ConnectorInterface $connector = null,
-        LoopInterface $loop = null
+        $connector = null,
+        $loop = null
     ) {
+        if ($connector !== null && !$connector instanceof ConnectorInterface) { // manual type check to support legacy PHP < 7.1
+            throw new \InvalidArgumentException('Argument #2 ($connector) expected null|React\Socket\ConnectorInterface');
+        }
+        if ($loop !== null && !$loop instanceof LoopInterface) { // manual type check to support legacy PHP < 7.1
+            throw new \InvalidArgumentException('Argument #3 ($loop) expected null|React\EventLoop\LoopInterface');
+        }
+
         $this->factory = new Factory($loop, $connector);
         $this->uri = $uri;
     }

--- a/tests/MysqlClientTest.php
+++ b/tests/MysqlClientTest.php
@@ -56,6 +56,18 @@ class MysqlClientTest extends BaseTestCase
         $this->assertSame($loop, $ref->getValue($factory));
     }
 
+    public function testContructorThrowsExceptionForInvalidConnector()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Argument #2 ($connector) expected null|React\Socket\ConnectorInterface');
+        new MysqlClient('localhost', 'connector');
+    }
+
+    public function testContructorThrowsExceptionForInvalidLoop()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Argument #3 ($loop) expected null|React\EventLoop\LoopInterface');
+        new MysqlClient('localhost', null, 'loop');
+    }
+
     public function testPingWillNotCloseConnectionWhenPendingConnectionFails()
     {
         $deferred = new Deferred();


### PR DESCRIPTION
This changeset improves PHP 8.4+ support by avoiding implicitly nullable types as discussed in https://github.com/reactphp/promise/pull/260. The same idea applies, but v0.7 requires manual type checks to support legacy PHP versions as the nullable type syntax requires PHP 7.1+ otherwise.

Builds on top of #186, #134, https://github.com/reactphp/promise/pull/260, https://github.com/reactphp/socket/pull/318, https://github.com/reactphp/promise-timer/pull/70 and https://github.com/reactphp/async/pull/87