### PR TITLE
Update test suite to use PCOV to avoid segfault with Xdebug 3.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: xdebug
+          coverage: ${{ matrix.php < 8.0 && 'xdebug' || 'pcov' }}
           ini-file: development
       - run: composer install
       - run: docker run -d --name mysql --net=host -e MYSQL_RANDOM_ROOT_PASSWORD=yes -e MYSQL_DATABASE=test -e MYSQL_USER=test -e MYSQL_PASSWORD=test mysql:5


### PR DESCRIPTION
This changeset updates the test suite to use PCOV instead of Xdebug on PHP 8+ to avoid a segfault with Xdebug 3.4.2 on PHP 8.1+ (https://bugs.xdebug.org/view.php?id=2332) as discussed in https://github.com/reactphp/socket/pull/323.

Builds on top of https://github.com/clue/framework-x/pull/278 and #204