### PR TITLE
Support `AuthSwitchRequest` to switch authentication plugin

### DIFF
--- a/src/Commands/AuthenticateCommand.php
+++ b/src/Commands/AuthenticateCommand.php
@@ -82,10 +82,6 @@ class AuthenticateCommand extends AbstractCommand
      */
     public function authenticatePacket($scramble, $authPlugin, Buffer $buffer)
     {
-        if ($authPlugin !== null && $authPlugin !== 'mysql_native_password' && $authPlugin !== 'caching_sha2_password') {
-            throw new \UnexpectedValueException('Unknown authentication plugin "' . addslashes($authPlugin) . '" requested by server');
-        }
-
         $clientFlags = Constants::CLIENT_LONG_PASSWORD |
             Constants::CLIENT_LONG_FLAG |
             Constants::CLIENT_LOCAL_FILES |
@@ -102,9 +98,26 @@ class AuthenticateCommand extends AbstractCommand
         return pack('VVc', $clientFlags, $this->maxPacketSize, $this->charsetNumber)
             . "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
             . $this->user . "\x00"
-            . $buffer->buildStringLen($authPlugin === 'caching_sha2_password' ? $this->authCachingSha2Password($scramble) : $this->authMysqlNativePassword($scramble))
+            . $buffer->buildStringLen($this->authResponse($scramble, $authPlugin))
             . $this->dbname . "\x00"
             . ($authPlugin !== null ? $authPlugin . "\0" : '');
+    }
+
+    /**
+     * @param string $scramble
+     * @param ?string $authPlugin
+     * @return string
+     * @throws \UnexpectedValueException for unsupported authentication plugin
+     */
+    public function authResponse($scramble, $authPlugin)
+    {
+        if ($authPlugin === null || $authPlugin === 'mysql_native_password') {
+            return $this->authMysqlNativePassword($scramble);
+        } elseif ($authPlugin === 'caching_sha2_password') {
+            return $this->authCachingSha2Password($scramble);
+        } else {
+            throw new \UnexpectedValueException('Unknown authentication plugin "' . addslashes($authPlugin) . '" requested by server');
+        }
     }
 
     /**

--- a/src/Io/Parser.php
+++ b/src/Io/Parser.php
@@ -269,7 +269,7 @@ class Parser
                 $this->debug(sprintf("AffectedRows: %d, InsertId: %d, WarningCount:%d", $this->affectedRows, $this->insertId, $this->warningCount));
                 $this->onSuccess();
                 $this->nextRequest();
-            } elseif ($fieldCount === 0xFE) {
+            } elseif ($fieldCount === 0xFE && $this->phase !== self::PHASE_AUTH_SENT) {
                 // EOF Packet
                 $packet->skip(4); // warn, status
                 if ($this->rsState === self::RS_STATE_ROW) {
@@ -282,6 +282,22 @@ class Parser
                     // move to next part of result set (header->field->row)
                     $this->debug('Result set next part');
                     ++$this->rsState;
+                }
+            } elseif ($fieldCount === 0xFE && $this->phase === self::PHASE_AUTH_SENT) {
+                // Protocol::AuthSwitchRequest packet
+                // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_auth_switch_request.html
+                $this->authPlugin = $packet->readStringNull();
+                $this->scramble = $packet->read($packet->length() - 1);
+                $packet->skip(1); // 0x00
+                $this->debug('Switched to authentication plugin: ' . $this->authPlugin);
+
+                try {
+                    assert($this->currCommand instanceof AuthenticateCommand);
+                    $this->sendPacket($this->currCommand->authResponse($this->scramble, $this->authPlugin));
+                    //$this->sendPacket($this->currCommand->authenticatePacket($this->scramble, $this->authPlugin, $this->buffer));
+                } catch (\UnexpectedValueException $e) {
+                    $this->onError($e);
+                    $this->stream->close();
                 }
             } elseif ($fieldCount === 0x01 && $this->phase === self::PHASE_AUTH_SENT && $this->authPlugin === 'caching_sha2_password') {
                 // Protocol::AuthMoreData packet

--- a/tests/Io/ParserTest.php
+++ b/tests/Io/ParserTest.php
@@ -83,6 +83,60 @@ class ParserTest extends BaseTestCase
         $stream->write("\x43\0\0\0\x0a\x38\x2e\x34\x2e\x35\0\x5e\0\0\0\x08\x0c\x41\x44\x12\x5e\x69\x59\0\xff\xff\xff\x02\0\xff\xdf\x15\0\0\0\0\0\0\0\0\0\0\x3c\x2c\x5e\x54\x06\x04\x01\x61\x01\x20\x79\x1b\0\x73\x68\x61\x32\x35\x36\x5f\x70\x61\x73\x73\x77\x6f\x72\x64\0");
     }
 
+    public function testParseAuthSwitchRequestWillSendAuthSwitchResponsePacket()
+    {
+        $stream = new ThroughStream();
+        $stream->on('close', $this->expectCallableNever());
+
+        $outgoing = new ThroughStream();
+        $outgoing->on('data', $this->expectCallableOnceWith("\x09\0\0\x01" . "encrypted"));
+
+        $executor = new Executor();
+
+        $command = $this->getMockBuilder('React\Mysql\Commands\AuthenticateCommand')->disableOriginalConstructor()->getMock();
+        $command->expects($this->once())->method('authResponse')->with('scramble', 'caching_sha2_password')->willReturn('encrypted');
+
+        $parser = new Parser(new CompositeStream($stream, $outgoing), $executor);
+        $parser->start();
+
+        $ref = new \ReflectionProperty($parser, 'phase');
+        $ref->setAccessible(true);
+        $ref->setValue($parser, Parser::PHASE_AUTH_SENT);
+
+        $ref = new \ReflectionProperty($parser, 'currCommand');
+        $ref->setAccessible(true);
+        $ref->setValue($parser, $command);
+
+        $stream->write("\x20\0\0\0" . "\xfe" . "caching_sha2_password" . "\0" . "scramble" . "\0");
+    }
+
+    public function testParseAuthSwitchRequestWithUnexpectedAuthPluginWillEmitErrorAndCloseConnection()
+    {
+        $stream = new ThroughStream();
+        $stream->on('close', $this->expectCallableOnce());
+
+        $outgoing = new ThroughStream();
+        $outgoing->on('data', $this->expectCallableNever());
+
+        $command = new AuthenticateCommand('root', '', 'test', 'utf8mb4');
+        $command->on('error', $this->expectCallableOnceWith(new \UnexpectedValueException('Unknown authentication plugin "sha256_password" requested by server')));
+
+        $executor = new Executor();
+
+        $parser = new Parser(new CompositeStream($stream, $outgoing), $executor);
+        $parser->start();
+
+        $ref = new \ReflectionProperty($parser, 'phase');
+        $ref->setAccessible(true);
+        $ref->setValue($parser, Parser::PHASE_AUTH_SENT);
+
+        $ref = new \ReflectionProperty($parser, 'currCommand');
+        $ref->setAccessible(true);
+        $ref->setValue($parser, $command);
+
+        $stream->write("\x19\0\0\0" . "\xfe" . "sha256_password" . "\0" . "scramble" . "\0");
+    }
+
     public function testParseAuthMoreDataWithFastAuthSuccessWillPrintDebugLogAndWaitForOkPacketWithoutSendingPacket()
     {
         $stream = new ThroughStream();
@@ -167,7 +221,7 @@ class ParserTest extends BaseTestCase
         $stream->write("\x04\0\0\0" . "\x01---");
     }
 
-    public function testAuthMoreDataWithCertificateWillEmitErrorAndCloseConnectionWhenEncryptingPasswordThrows()
+    public function testParseAuthMoreDataWithCertificateWillEmitErrorAndCloseConnectionWhenEncryptingPasswordThrows()
     {
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());


### PR DESCRIPTION
This changeset adds support for the `AuthSwitchRequest` to switch authentication plugins. The MySQL server can send this packet to ask the client to use another authentication method (https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_auth_switch_request.html).

For instance, this is required to make Amazon RDS work in my tests. In my tests, the server first requests `mysql_native_password` which is then fulfilled by the client, and next switches to `caching_sha2_password` afterwards, asking the client to authenticate again. While I agree this may look strange, it may make sense depending on server configuration internals and is completely in line with the MySQL protocol specification.

With these changes applied, I can successfully connect to my Amazon RDS server and process any queries as usual. Prior to applying these changes, I would get a protocol exception instead:

```
Connection to mysql://user:***@example.amazonaws.com:3306/example failed during authentication: Unexpected protocol error, received malformed packet with 39 unknown byte(s)
```

The affected code has 100% code coverage and has been tested against a number of MySQL server versions. The tests confirm it should continue to work for legacy servers not using authentication plugins or newer MySQL server versions using the existing `mysql_native_password` authentication or newer `caching_sha2_password` authentication. As discussed in #196 and elsewhere, I'll follow-up with a separate PR to add more MySQL server versions to our test matrix, but I've yet to find a combination that requires the `AuthSwitchRequest`.

Builds on top of #207 and #206