### PR TITLE
Update test matrix to include full MySQL 8 and MySQL 9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
           - 5.4
         include:
           - php: 8.4
+            rdbms: mysql:9
+          - php: 8.4
+            rdbms: mysql:8
+          - php: 8.4
             rdbms: mariadb:10
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -416,6 +416,12 @@ extensions and supports running on legacy PHP 5.4 through current PHP 8+ and
 HHVM.
 It's *highly recommended to use the latest supported PHP version* for this project.
 
+This project supports connecting to a variety of MySQL database versions and
+compatible projects using the MySQL protocol. The `caching_sha2_password`
+authentication plugin (default in MySQL 8+) requires PHP 7.1+ and `ext-openssl`
+to be installed, while the older `mysql_native_password` authentication plugin
+(default in MySQL 5.7) is supported across all supported PHP versions.
+
 ## Tests
 
 To run the test suite, you first need to clone this repo and then install all

--- a/tests/NoResultQueryTest.php
+++ b/tests/NoResultQueryTest.php
@@ -76,7 +76,8 @@ CREATE TABLE IF NOT EXISTS `book` (
 )';
 
         $connection->query($sql)->then(function (MysqlResult $command) {
-            $this->assertEquals(1, $command->warningCount);
+            // 3 warnings on MySQL 8+, 1 warning on legacy MySQL 5
+            $this->assertGreaterThanOrEqual(1, $command->warningCount);
         });
 
         $connection->quit();


### PR DESCRIPTION
This changeset updates the test matrix to include full MySQL 8 and MySQL 9 support. It only improves our tests and documentation to emphasize we officially support MySQL 8+ and other compatible projects, building on top of our recent MySQL protocol improvements.

Builds on top of #207 and #196
Refs #112