### PR TITLE
Make `MysqlClient` constructor throw if given `$uri` is invalid

### DIFF
--- a/src/Io/Factory.php
+++ b/src/Io/Factory.php
@@ -165,34 +165,23 @@ class Factory
         #[\SensitiveParameter]
         $uri
     ) {
-        if (strpos($uri, '://') === false) {
-            $uri = 'mysql://' . $uri;
-        }
-
         $parts = parse_url($uri);
         $uri = preg_replace('#:[^:/]*@#', ':***@', $uri);
-        if (!isset($parts['scheme'], $parts['host']) || $parts['scheme'] !== 'mysql') {
-            return \React\Promise\reject(new \InvalidArgumentException(
-                'Invalid MySQL URI given (EINVAL)',
-                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
-            ));
-        }
+        assert(is_array($parts) && isset($parts['scheme'], $parts['host']));
+        assert($parts['scheme'] === 'mysql');
 
         $args = [];
         if (isset($parts['query'])) {
             parse_str($parts['query'], $args);
         }
 
-        try {
-            $authCommand = new AuthenticateCommand(
-                isset($parts['user']) ? rawurldecode($parts['user']) : 'root',
-                isset($parts['pass']) ? rawurldecode($parts['pass']) : '',
-                isset($parts['path']) ? rawurldecode(ltrim($parts['path'], '/')) : '',
-                isset($args['charset']) ? $args['charset'] : 'utf8mb4'
-            );
-        } catch (\InvalidArgumentException $e) {
-            return \React\Promise\reject($e);
-        }
+        /** @throws void already validated in MysqlClient ctor */
+        $authCommand = new AuthenticateCommand(
+            isset($parts['user']) ? rawurldecode($parts['user']) : 'root',
+            isset($parts['pass']) ? rawurldecode($parts['pass']) : '',
+            isset($parts['path']) ? rawurldecode(ltrim($parts['path'], '/')) : '',
+            isset($args['charset']) ? $args['charset'] : 'utf8mb4'
+        );
 
         $connecting = $this->connector->connect(
             $parts['host'] . ':' . (isset($parts['port']) ? $parts['port'] : 3306)

--- a/src/MysqlClient.php
+++ b/src/MysqlClient.php
@@ -4,6 +4,7 @@ namespace React\Mysql;
 
 use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
+use React\Mysql\Commands\AuthenticateCommand;
 use React\Mysql\Io\Connection;
 use React\Mysql\Io\Factory;
 use React\Promise\Deferred;
@@ -80,6 +81,7 @@ class MysqlClient extends EventEmitter
      * @param string $uri
      * @param ?ConnectorInterface $connector
      * @param ?LoopInterface $loop
+     * @throws \InvalidArgumentException if $uri is not a valid MySQL URI
      */
     public function __construct(
         #[\SensitiveParameter]
@@ -87,6 +89,29 @@ class MysqlClient extends EventEmitter
         $connector = null,
         $loop = null
     ) {
+        if (strpos($uri, '://') === false) {
+            $uri = 'mysql://' . $uri;
+        }
+
+        $parts = parse_url($uri);
+        if ($parts === false || !isset($parts['scheme'], $parts['host']) || $parts['scheme'] !== 'mysql') {
+            $uri = preg_replace('#:[^:/]*@#', ':***@', $uri);
+            throw new \InvalidArgumentException(
+                'Invalid MySQL URI "' . $uri . '" (EINVAL)',
+                defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            );
+        }
+
+        if (isset($parts['query'])) {
+            $query = [];
+            parse_str($parts['query'], $query);
+
+            // validate charset if given
+            if (isset($query['charset'])) {
+                new AuthenticateCommand('', '', '', $query['charset']);
+            }
+        }
+
         if ($connector !== null && !$connector instanceof ConnectorInterface) { // manual type check to support legacy PHP < 7.1
             throw new \InvalidArgumentException('Argument #2 ($connector) expected null|React\Socket\ConnectorInterface');
         }

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -25,7 +25,7 @@ class BaseTestCase extends TestCase
     {
         $parts = $params + $this->getConnectionOptions();
 
-        return rawurlencode($parts['user']) . ':' . rawurlencode($parts['passwd']) . '@' . $parts['host'] . ':' . $parts['port'] . '/' . rawurlencode($parts['dbname']);
+        return 'mysql://' . rawurlencode($parts['user']) . ':' . rawurlencode($parts['passwd']) . '@' . $parts['host'] . ':' . $parts['port'] . '/' . rawurlencode($parts['dbname']);
     }
 
     /**

--- a/tests/Io/FactoryTest.php
+++ b/tests/Io/FactoryTest.php
@@ -30,7 +30,7 @@ class FactoryTest extends BaseTestCase
         $connector->expects($this->once())->method('connect')->with('127.0.0.1:3306')->willReturn($pending);
 
         $factory = new Factory($loop, $connector);
-        $factory->createConnection('127.0.0.1');
+        $factory->createConnection('mysql://127.0.0.1');
     }
 
     public function testConnectWillUseGivenScheme()
@@ -44,28 +44,6 @@ class FactoryTest extends BaseTestCase
         $factory->createConnection('mysql://127.0.0.1');
     }
 
-    public function testConnectWillRejectWhenGivenInvalidScheme()
-    {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
-
-        $factory = new Factory($loop, $connector);
-
-        $promise = $factory->createConnection('foo://127.0.0.1');
-
-        $promise->then(null, $this->expectCallableOnceWith(
-            $this->logicalAnd(
-                $this->isInstanceOf('InvalidArgumentException'),
-                $this->callback(function (\InvalidArgumentException $e) {
-                    return $e->getMessage() === 'Invalid MySQL URI given (EINVAL)';
-                }),
-                $this->callback(function (\InvalidArgumentException $e) {
-                    return $e->getCode() === (defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22);
-                })
-            )
-        ));
-    }
-
     public function testConnectWillUseGivenHostAndGivenPort()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -74,7 +52,7 @@ class FactoryTest extends BaseTestCase
         $connector->expects($this->once())->method('connect')->with('127.0.0.1:1234')->willReturn($pending);
 
         $factory = new Factory($loop, $connector);
-        $factory->createConnection('127.0.0.1:1234');
+        $factory->createConnection('mysql://127.0.0.1:1234');
     }
 
     public function testConnectWillUseGivenUserInfoAsDatabaseCredentialsAfterUrldecoding()
@@ -87,7 +65,7 @@ class FactoryTest extends BaseTestCase
         $connector->expects($this->once())->method('connect')->with('127.0.0.1:3306')->willReturn(\React\Promise\resolve($connection));
 
         $factory = new Factory($loop, $connector);
-        $promise = $factory->createConnection('user%21@127.0.0.1');
+        $promise = $factory->createConnection('mysql://user%21@127.0.0.1');
 
         $promise->then($this->expectCallableNever(), $this->expectCallableNever());
 
@@ -104,46 +82,11 @@ class FactoryTest extends BaseTestCase
         $connector->expects($this->once())->method('connect')->with('127.0.0.1:3306')->willReturn(\React\Promise\resolve($connection));
 
         $factory = new Factory($loop, $connector);
-        $promise = $factory->createConnection('127.0.0.1/test%20database');
+        $promise = $factory->createConnection('mysql://127.0.0.1/test%20database');
 
         $promise->then($this->expectCallableNever(), $this->expectCallableNever());
 
         $connection->emit('data', ["\x33\0\0\0" . "\x0a" . "mysql\0" . str_repeat("\0", 44)]);
-    }
-
-    public function testConnectWithInvalidUriWillRejectWithoutConnecting()
-    {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
-        $connector->expects($this->never())->method('connect');
-
-        $factory = new Factory($loop, $connector);
-        $promise = $factory->createConnection('///');
-
-        $promise->then(null, $this->expectCallableOnceWith(
-            $this->logicalAnd(
-                $this->isInstanceOf('InvalidArgumentException'),
-                $this->callback(function (\InvalidArgumentException $e) {
-                    return $e->getMessage() === 'Invalid MySQL URI given (EINVAL)';
-                }),
-                $this->callback(function (\InvalidArgumentException $e) {
-                    return $e->getCode() === (defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22);
-                })
-            )
-        ));
-    }
-
-    public function testConnectWithInvalidCharsetWillRejectWithoutConnecting()
-    {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
-        $connector->expects($this->never())->method('connect');
-
-        $factory = new Factory($loop, $connector);
-        $promise = $factory->createConnection('localhost?charset=unknown');
-
-        $this->assertInstanceof('React\Promise\PromiseInterface', $promise);
-        $promise->then(null, $this->expectCallableOnce());
     }
 
     public function testConnectWithInvalidHostRejectsWithConnectionError()
@@ -204,7 +147,7 @@ class FactoryTest extends BaseTestCase
             $this->logicalAnd(
                 $this->isInstanceOf('RuntimeException'),
                 $this->callback(function (\RuntimeException $e) use ($uri) {
-                    return $e->getMessage() === 'Connection to mysql://' . $uri . ' failed during authentication: Connection closed by peer (ECONNRESET)';
+                    return $e->getMessage() === 'Connection to ' . $uri . ' failed during authentication: Connection closed by peer (ECONNRESET)';
                 }),
                 $this->callback(function (\RuntimeException $e) {
                     return $e->getCode() === (defined('SOCKET_ECONNRESET') ? SOCKET_ECONNRESET : 104);
@@ -244,7 +187,7 @@ class FactoryTest extends BaseTestCase
     {
         $factory = new Factory();
 
-        $uri = 'mysql://' . $this->getConnectionString();
+        $uri = $this->getConnectionString();
 
         $old = ini_get('default_socket_timeout');
         ini_set('default_socket_timeout', '0');
@@ -439,7 +382,7 @@ class FactoryTest extends BaseTestCase
         $connector->expects($this->once())->method('connect')->willReturn(\React\Promise\reject(new \RuntimeException('Failed', 123)));
 
         $factory = new Factory($loop, $connector);
-        $promise = $factory->createConnection('user:secret@127.0.0.1');
+        $promise = $factory->createConnection('mysql://user:secret@127.0.0.1');
 
         $promise->then(null, $this->expectCallableOnceWith(
             $this->logicalAnd(
@@ -457,10 +400,6 @@ class FactoryTest extends BaseTestCase
     public function provideUris()
     {
         return [
-            [
-                'localhost',
-                'mysql://localhost'
-            ],
             [
                 'mysql://localhost',
                 'mysql://localhost'
@@ -520,7 +459,7 @@ class FactoryTest extends BaseTestCase
         $connector->expects($this->once())->method('connect')->willReturn($pending);
 
         $factory = new Factory($loop, $connector);
-        $promise = $factory->createConnection('127.0.0.1');
+        $promise = $factory->createConnection('mysql://127.0.0.1');
 
         $promise->cancel();
 
@@ -547,7 +486,7 @@ class FactoryTest extends BaseTestCase
         $connector->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $factory = new Factory($loop, $connector);
-        $promise = $factory->createConnection('127.0.0.1');
+        $promise = $factory->createConnection('mysql://127.0.0.1');
 
         $promise->cancel();
 

--- a/tests/MysqlClientTest.php
+++ b/tests/MysqlClientTest.php
@@ -56,6 +56,73 @@ class MysqlClientTest extends BaseTestCase
         $this->assertSame($loop, $ref->getValue($factory));
     }
 
+    public static function provideInvalidUris()
+    {
+        return [
+            [
+                '',
+                'mysql://'
+            ],
+            [
+                'localhost:100000',
+                'mysql://localhost:100000'
+            ],
+            [
+                'tcp://localhost',
+                'tcp://localhost'
+            ],
+            [
+                'mysql://',
+                'mysql://'
+            ],
+            [
+                'mysql+unix://',
+                'mysql+unix://'
+            ],
+            [
+                'user@localhost:100000',
+                'mysql://user@localhost:100000'
+            ],
+            [
+                ':pass@localhost:100000',
+                'mysql://:***@localhost:100000'
+            ],
+            [
+                'user:@localhost:100000',
+                'mysql://user:***@localhost:100000'
+            ],
+            [
+                'user:pass@localhost:100000',
+                'mysql://user:***@localhost:100000'
+            ],
+            [
+                'user@',
+                'mysql://user@'
+            ],
+            [
+                'user:pass@',
+                'mysql://user:***@'
+            ]
+        ];
+    }
+
+    /** @dataProvider provideInvalidUris */
+    public function testContructorThrowsExceptionForInvalidUri($uri, $message)
+    {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Invalid MySQL URI "' . $message . '" (EINVAL)',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        );
+        new MysqlClient($uri);
+    }
+
+    public function testContructorThrowsExceptionForInvalidCharset()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Unsupported charset selected');
+        new MysqlClient('localhost?charset=unknown');
+    }
+
     public function testContructorThrowsExceptionForInvalidConnector()
     {
         $this->setExpectedException('InvalidArgumentException', 'Argument #2 ($connector) expected null|React\Socket\ConnectorInterface');
@@ -75,7 +142,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -100,7 +167,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -124,7 +191,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -154,7 +221,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -177,7 +244,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -197,7 +264,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -218,7 +285,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -235,7 +302,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\reject(new \RuntimeException()));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -255,7 +322,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -273,7 +340,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -296,7 +363,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -325,7 +392,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -355,7 +422,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -383,7 +450,7 @@ class MysqlClientTest extends BaseTestCase
         );
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -413,7 +480,7 @@ class MysqlClientTest extends BaseTestCase
         );
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $mysql->on('close', $this->expectCallableNever());
 
@@ -440,7 +507,7 @@ class MysqlClientTest extends BaseTestCase
         );
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -462,7 +529,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -487,7 +554,7 @@ class MysqlClientTest extends BaseTestCase
         );
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -524,7 +591,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -547,7 +614,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -567,7 +634,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -588,7 +655,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -617,7 +684,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -648,7 +715,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -676,7 +743,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -711,7 +778,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -740,7 +807,7 @@ class MysqlClientTest extends BaseTestCase
         );
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -771,7 +838,7 @@ class MysqlClientTest extends BaseTestCase
         );
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $mysql->on('close', $this->expectCallableNever());
 
@@ -799,7 +866,7 @@ class MysqlClientTest extends BaseTestCase
         );
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -821,7 +888,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -849,7 +916,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -869,7 +936,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -889,7 +956,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -906,7 +973,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\reject(new \RuntimeException()));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -926,7 +993,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -944,7 +1011,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -967,7 +1034,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -993,7 +1060,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -1020,7 +1087,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -1048,7 +1115,7 @@ class MysqlClientTest extends BaseTestCase
         );
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -1078,7 +1145,7 @@ class MysqlClientTest extends BaseTestCase
         );
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $mysql->on('close', $this->expectCallableNever());
 
@@ -1105,7 +1172,7 @@ class MysqlClientTest extends BaseTestCase
         );
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -1127,7 +1194,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -1152,7 +1219,7 @@ class MysqlClientTest extends BaseTestCase
         );
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -1186,7 +1253,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -1214,7 +1281,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1238,7 +1305,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1264,7 +1331,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1282,7 +1349,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1301,7 +1368,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($promise);
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1324,7 +1391,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1349,7 +1416,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1373,7 +1440,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1396,7 +1463,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($promise);
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1417,7 +1484,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1435,7 +1502,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1455,7 +1522,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->exactly(2))->method('createConnection')->willReturn(\React\Promise\reject($error));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1475,7 +1542,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1497,7 +1564,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1523,7 +1590,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1539,7 +1606,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->never())->method('createConnection');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1561,7 +1628,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($promise);
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1581,7 +1648,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1610,7 +1677,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1631,7 +1698,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1661,7 +1728,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1693,7 +1760,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $mysql = new MysqlClient('', null, $loop);
+        $mysql = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($mysql, 'factory');
         $ref->setAccessible(true);
@@ -1714,7 +1781,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->never())->method('createConnection');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1733,7 +1800,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($deferred->promise());
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1753,7 +1820,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1774,7 +1841,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($promise);
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1801,7 +1868,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1822,7 +1889,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1843,7 +1910,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1866,7 +1933,7 @@ class MysqlClientTest extends BaseTestCase
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1887,7 +1954,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->once())->method('createConnection')->willReturn($promise);
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1907,7 +1974,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->never())->method('createConnection');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1926,7 +1993,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->never())->method('createConnection');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1944,7 +2011,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->never())->method('createConnection');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -1963,7 +2030,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->never())->method('createConnection');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);


### PR DESCRIPTION
This changeset updates the `MysqlClient` constructor to throw if the given `$uri` is invalid. Previously, it would only reject on the next command invoked on this instance. Moving this logic to the constructor makes it easier to detect invalid URIs for consumers of this API and should not otherwise affect "normal" operation in any way.

Builds on top of https://github.com/clue/reactphp-redis/pull/163, #203, #186, #141, #135 and others
Refs #147