### PR TITLE
Validate query parameters and reject non-scalars

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ given event loop instance.
 
 #### query()
 
-The `query(string $query, array $params = []): PromiseInterface<MysqlResult>` method can be used to
+The `query(string $query, list<string|int|float|bool|null> $params = []): PromiseInterface<MysqlResult>` method can be used to
 perform an async query.
 
 This method returns a promise that will resolve with a `MysqlResult` on
@@ -258,7 +258,7 @@ suited for exposing multiple possible results.
 
 #### queryStream()
 
-The `queryStream(string $sql, array $params = []): ReadableStreamInterface` method can be used to
+The `queryStream(string $sql, list<string|int|float|bool|null> $params = []): ReadableStreamInterface` method can be used to
 perform an async query and stream the rows of the result set.
 
 This method returns a readable stream that will emit each row of the

--- a/src/Io/Connection.php
+++ b/src/Io/Connection.php
@@ -90,16 +90,8 @@ class Connection extends EventEmitter
         return $this->parser->isBusy() || !$this->executor->isIdle();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function query($sql, array $params = [])
+    public function query(Query $query)
     {
-        $query = new Query($sql);
-        if ($params) {
-            $query->bindParamsFromArray($params);
-        }
-
         $command = new QueryCommand();
         $command->setQuery($query);
         try {
@@ -146,13 +138,8 @@ class Connection extends EventEmitter
         return $deferred->promise();
     }
 
-    public function queryStream($sql, $params = [])
+    public function queryStream(Query $query)
     {
-        $query = new Query($sql);
-        if ($params) {
-            $query->bindParamsFromArray($params);
-        }
-
         $command = new QueryCommand();
         $command->setQuery($query);
         $this->_doCommand($command);

--- a/src/Io/Query.php
+++ b/src/Io/Query.php
@@ -44,9 +44,16 @@ class Query
     /**
      * @param string $sql
      * @param list<string|int|float|bool|null> $params
+     * @throws \InvalidArgumentException if given $params are invalid
      */
     public function __construct($sql, array $params = [])
     {
+        foreach ($params as $param) {
+            if (!\is_scalar($param) && $param !== null) {
+                throw new \InvalidArgumentException('Query param must be of type string|int|float|bool|null, ' . (\is_object($param) ? \get_class($param) : \gettype($param)) . ' given');
+            }
+        }
+
         $this->sql = $sql;
         $this->builtSql = $params ? null : $sql;
         $this->params = $params;
@@ -76,9 +83,6 @@ class Query
                 break;
             case 'NULL':
                 $value = 'NULL';
-                break;
-            default:
-                throw new \InvalidArgumentException(sprintf('Not supported value type of %s.', $type));
                 break;
         }
 

--- a/src/Io/Query.php
+++ b/src/Io/Query.php
@@ -41,23 +41,15 @@ class Query
             //"_"    => "\\_",
         ];
 
-    public function __construct($sql)
-    {
-        $this->sql = $this->builtSql = $sql;
-    }
-
     /**
-     * Binding params for the query, multiple arguments support.
-     *
+     * @param string $sql
      * @param list<string|int|float|bool|null> $params
-     * @return $this
      */
-    public function bindParamsFromArray(array $params)
+    public function __construct($sql, array $params = [])
     {
-        $this->builtSql = null;
-        $this->params   = $params;
-
-        return $this;
+        $this->sql = $sql;
+        $this->builtSql = $params ? null : $sql;
+        $this->params = $params;
     }
 
     public function escape($str)

--- a/src/Io/Query.php
+++ b/src/Io/Query.php
@@ -49,36 +49,13 @@ class Query
     /**
      * Binding params for the query, multiple arguments support.
      *
-     * @param  mixed              $param
-     * @return self
+     * @param list<string|int|float|bool|null> $params
+     * @return $this
      */
-    public function bindParams()
-    {
-        $this->builtSql = null;
-        $this->params   = func_get_args();
-
-        return $this;
-    }
-
     public function bindParamsFromArray(array $params)
     {
         $this->builtSql = null;
         $this->params   = $params;
-
-        return $this;
-    }
-
-    /**
-     * Binding params for the query, multiple arguments support.
-     *
-     * @param  mixed              $param
-     * @return self
-     *                                  @deprecated
-     */
-    public function params()
-    {
-        $this->params   = func_get_args();
-        $this->builtSql = null;
 
         return $this;
     }
@@ -104,13 +81,6 @@ class Query
                 break;
             case 'string':
                 $value = "'" . $this->escape($value) . "'";
-                break;
-            case 'array':
-                $nvalue = [];
-                foreach ($value as $v) {
-                    $nvalue[] = $this->resolveValueForSql($v);
-                }
-                $value = implode(',', $nvalue);
                 break;
             case 'NULL':
                 $value = 'NULL';

--- a/src/MysqlClient.php
+++ b/src/MysqlClient.php
@@ -6,6 +6,7 @@ use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
 use React\Mysql\Io\Connection;
 use React\Mysql\Io\Factory;
+use React\Mysql\Io\Query;
 use React\Promise\Deferred;
 use React\Promise\Promise;
 use React\Promise\PromiseInterface;
@@ -163,8 +164,10 @@ class MysqlClient extends EventEmitter
             return \React\Promise\reject(new Exception('Connection closed'));
         }
 
-        return $this->getConnection()->then(function (Connection $connection) use ($sql, $params) {
-            return $connection->query($sql, $params)->then(function (MysqlResult $result) use ($connection) {
+        $query = new Query($sql, $params);
+
+        return $this->getConnection()->then(function (Connection $connection) use ($query) {
+            return $connection->query($query)->then(function (MysqlResult $result) use ($connection) {
                 $this->handleConnectionReady($connection);
                 return $result;
             }, function (\Exception $e) use ($connection) {
@@ -239,9 +242,11 @@ class MysqlClient extends EventEmitter
             throw new Exception('Connection closed');
         }
 
+        $query = new Query($sql, $params);
+
         return \React\Promise\Stream\unwrapReadable(
-            $this->getConnection()->then(function (Connection $connection) use ($sql, $params) {
-                $stream = $connection->queryStream($sql, $params);
+            $this->getConnection()->then(function (Connection $connection) use ($query) {
+                $stream = $connection->queryStream($query);
 
                 $stream->on('end', function () use ($connection) {
                     $this->handleConnectionReady($connection);

--- a/src/MysqlClient.php
+++ b/src/MysqlClient.php
@@ -157,14 +157,15 @@ class MysqlClient extends EventEmitter
      * @param list<string|int|float|bool|null> $params Parameters which should be bound to query
      * @return PromiseInterface<MysqlResult>
      *     Resolves with a `MysqlResult` on success or rejects with an `Exception` on error.
+     * @throws \InvalidArgumentException if given $params are invalid
      */
     public function query($sql, array $params = [])
     {
+        $query = new Query($sql, $params);
+
         if ($this->closed || $this->quitting) {
             return \React\Promise\reject(new Exception('Connection closed'));
         }
-
-        $query = new Query($sql, $params);
 
         return $this->getConnection()->then(function (Connection $connection) use ($query) {
             return $connection->query($query)->then(function (MysqlResult $result) use ($connection) {
@@ -235,14 +236,16 @@ class MysqlClient extends EventEmitter
      * @param string $sql SQL statement
      * @param list<string|int|float|bool|null> $params Parameters which should be bound to query
      * @return ReadableStreamInterface
+     * @throws \InvalidArgumentException if given $params are invalid
+     * @throws Exception if connection is already closed/closing
      */
     public function queryStream($sql, array $params = [])
     {
+        $query = new Query($sql, $params);
+
         if ($this->closed || $this->quitting) {
             throw new Exception('Connection closed');
         }
-
-        $query = new Query($sql, $params);
 
         return \React\Promise\Stream\unwrapReadable(
             $this->getConnection()->then(function (Connection $connection) use ($query) {

--- a/src/MysqlClient.php
+++ b/src/MysqlClient.php
@@ -152,8 +152,8 @@ class MysqlClient extends EventEmitter
      * could allow for possible SQL injection attacks and this API is not
      * suited for exposing multiple possible results.
      *
-     * @param string $sql    SQL statement
-     * @param array  $params Parameters which should be bound to query
+     * @param string $sql SQL statement
+     * @param list<string|int|float|bool|null> $params Parameters which should be bound to query
      * @return PromiseInterface<MysqlResult>
      *     Resolves with a `MysqlResult` on success or rejects with an `Exception` on error.
      */
@@ -229,11 +229,11 @@ class MysqlClient extends EventEmitter
      * could allow for possible SQL injection attacks and this API is not
      * suited for exposing multiple possible results.
      *
-     * @param string $sql    SQL statement
-     * @param array  $params Parameters which should be bound to query
+     * @param string $sql SQL statement
+     * @param list<string|int|float|bool|null> $params Parameters which should be bound to query
      * @return ReadableStreamInterface
      */
-    public function queryStream($sql, $params = [])
+    public function queryStream($sql, array $params = [])
     {
         if ($this->closed || $this->quitting) {
             throw new Exception('Connection closed');

--- a/tests/Io/ConnectionTest.php
+++ b/tests/Io/ConnectionTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\Mysql\Io;
 
 use React\Mysql\Io\Connection;
+use React\Mysql\Io\Query;
 use React\Tests\Mysql\BaseTestCase;
 
 class ConnectionTest extends BaseTestCase
@@ -22,7 +23,7 @@ class ConnectionTest extends BaseTestCase
 
         $connection = new Connection($stream, $executor, $parser, $loop, null);
 
-        $connection->query('SELECT 1');
+        $connection->query(new Query('SELECT 1'));
 
         $this->assertTrue($connection->isBusy());
     }
@@ -57,7 +58,7 @@ class ConnectionTest extends BaseTestCase
         $loop->expects($this->never())->method('addTimer');
 
         $conn = new Connection($stream, $executor, $parser, $loop, null);
-        $conn->query('SELECT 1');
+        $conn->query(new Query('SELECT 1'));
     }
 
     public function testQueryWillReturnResolvedPromiseAndStartIdleTimerWhenQueryCommandEmitsSuccess()
@@ -81,7 +82,7 @@ class ConnectionTest extends BaseTestCase
 
         $this->assertNull($currentCommand);
 
-        $promise = $connection->query('SELECT 1');
+        $promise = $connection->query(new Query('SELECT 1'));
 
         $promise->then($this->expectCallableOnceWith($this->isInstanceOf('React\Mysql\MysqlResult')));
 
@@ -110,7 +111,7 @@ class ConnectionTest extends BaseTestCase
 
         $this->assertNull($currentCommand);
 
-        $promise = $connection->query('SELECT 1');
+        $promise = $connection->query(new Query('SELECT 1'));
 
         $promise->then($this->expectCallableOnceWith($this->isInstanceOf('React\Mysql\MysqlResult')));
 
@@ -139,7 +140,7 @@ class ConnectionTest extends BaseTestCase
 
         $this->assertNull($currentCommand);
 
-        $promise = $connection->query('SELECT 1');
+        $promise = $connection->query(new Query('SELECT 1'));
 
         $promise->then($this->expectCallableOnceWith($this->isInstanceOf('React\Mysql\MysqlResult')));
 
@@ -166,7 +167,7 @@ class ConnectionTest extends BaseTestCase
 
         $this->assertNull($currentCommand);
 
-        $promise = $connection->query('SELECT 1');
+        $promise = $connection->query(new Query('SELECT 1'));
 
         $promise->then($this->expectCallableOnceWith($this->isInstanceOf('React\Mysql\MysqlResult')));
 
@@ -195,7 +196,7 @@ class ConnectionTest extends BaseTestCase
 
         $this->assertNull($currentCommand);
 
-        $promise = $connection->query('SELECT 1');
+        $promise = $connection->query(new Query('SELECT 1'));
 
         $promise->then(null, $this->expectCallableOnce());
 
@@ -230,7 +231,7 @@ class ConnectionTest extends BaseTestCase
 
         $this->assertNull($currentCommand);
 
-        $connection->query('SELECT 1');
+        $connection->query(new Query('SELECT 1'));
 
         $this->assertNotNull($currentCommand);
         $currentCommand->emit('success');
@@ -269,7 +270,7 @@ class ConnectionTest extends BaseTestCase
 
         $this->assertNull($currentCommand);
 
-        $connection->query('SELECT 1');
+        $connection->query(new Query('SELECT 1'));
 
         $this->assertNotNull($currentCommand);
         $currentCommand->emit('success');
@@ -300,8 +301,8 @@ class ConnectionTest extends BaseTestCase
 
         $this->assertNull($currentCommand);
 
-        $connection->query('SELECT 1');
-        $connection->query('SELECT 2');
+        $connection->query(new Query('SELECT 1'));
+        $connection->query(new Query('SELECT 2'));
 
         $this->assertNotNull($currentCommand);
         $currentCommand->emit('success');
@@ -328,12 +329,12 @@ class ConnectionTest extends BaseTestCase
 
         $this->assertNull($currentCommand);
 
-        $connection->query('SELECT 1');
+        $connection->query(new Query('SELECT 1'));
 
         $this->assertNotNull($currentCommand);
         $currentCommand->emit('success');
 
-        $connection->query('SELECT 2');
+        $connection->query(new Query('SELECT 2'));
     }
 
     public function testQueryStreamWillEnqueueOneCommand()
@@ -350,7 +351,7 @@ class ConnectionTest extends BaseTestCase
         $loop->expects($this->never())->method('addTimer');
 
         $conn = new Connection($stream, $executor, $parser, $loop, null);
-        $conn->queryStream('SELECT 1');
+        $conn->queryStream(new Query('SELECT 1'));
     }
 
     public function testQueryStreamWillReturnStreamThatWillEmitEndEventAndStartIdleTimerWhenQueryCommandEmitsSuccess()
@@ -374,7 +375,7 @@ class ConnectionTest extends BaseTestCase
 
         $this->assertNull($currentCommand);
 
-        $stream = $connection->queryStream('SELECT 1');
+        $stream = $connection->queryStream(new Query('SELECT 1'));
 
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('close', $this->expectCallableOnce());
@@ -404,7 +405,7 @@ class ConnectionTest extends BaseTestCase
 
         $this->assertNull($currentCommand);
 
-        $stream = $connection->queryStream('SELECT 1');
+        $stream = $connection->queryStream(new Query('SELECT 1'));
 
         $stream->on('error', $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException')));
         $stream->on('close', $this->expectCallableOnce());
@@ -641,7 +642,7 @@ class ConnectionTest extends BaseTestCase
 
         $conn = new Connection($stream, $executor, $parser, $loop, null);
         $conn->quit();
-        $promise = $conn->query('SELECT 1');
+        $promise = $conn->query(new Query('SELECT 1'));
 
         $promise->then(null, $this->expectCallableOnceWith(
             $this->logicalAnd(
@@ -668,7 +669,7 @@ class ConnectionTest extends BaseTestCase
 
         $conn = new Connection($stream, $executor, $parser, $loop, null);
         $conn->close();
-        $promise = $conn->query('SELECT 1');
+        $promise = $conn->query(new Query('SELECT 1'));
 
         $promise->then(null, $this->expectCallableOnceWith(
             $this->logicalAnd(
@@ -697,7 +698,7 @@ class ConnectionTest extends BaseTestCase
         $conn->quit();
 
         try {
-            $conn->queryStream('SELECT 1');
+            $conn->queryStream(new Query('SELECT 1'));
         } catch (\RuntimeException $e) {
             $this->assertEquals('Connection closing (ENOTCONN)', $e->getMessage());
             $this->assertEquals(defined('SOCKET_ENOTCONN') ? SOCKET_ENOTCONN : 107, $e->getCode());

--- a/tests/Io/QueryTest.php
+++ b/tests/Io/QueryTest.php
@@ -2,11 +2,17 @@
 
 namespace React\Tests\Mysql\Io;
 
-use PHPUnit\Framework\TestCase;
 use React\Mysql\Io\Query;
+use React\Tests\Mysql\BaseTestCase;
 
-class QueryTest extends TestCase
+class QueryTest extends BaseTestCase
 {
+    public function testCtorThrowsForInvalidParams()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Query param must be of type string|int|float|bool|null, resource given');
+        new Query('SELECT ?', [tmpfile()]);
+    }
+
     public function testBindParams()
     {
         $query = new Query('select * from test where id = ? and name = ?', [100, 'test']);

--- a/tests/Io/QueryTest.php
+++ b/tests/Io/QueryTest.php
@@ -10,19 +10,19 @@ class QueryTest extends TestCase
     public function testBindParams()
     {
         $query = new Query('select * from test where id = ? and name = ?');
-        $sql   = $query->bindParams(100, 'test')->getSql();
+        $sql   = $query->bindParamsFromArray([100, 'test'])->getSql();
         $this->assertEquals("select * from test where id = 100 and name = 'test'", $sql);
 
-        $query = new Query('select * from test where id in (?) and name = ?');
-        $sql   = $query->bindParams([1, 2], 'test')->getSql();
+        $query = new Query('select * from test where id in (?,?) and name = ?');
+        $sql   = $query->bindParamsFromArray([1, 2, 'test'])->getSql();
         $this->assertEquals("select * from test where id in (1,2) and name = 'test'", $sql);
         /*
         $query = new Query('select * from test where id = :id and name = :name');
-        $sql   = $query->params([':id' => 100, ':name' => 'test'])->getSql();
+        $sql   = $query->bindParamsFromArray([':id' => 100, ':name' => 'test'])->getSql();
         $this->assertEquals("select * from test where id = 100 and name = 'test'", $sql);
 
         $query = new Query('select * from test where id = :id and name = ?');
-        $sql   = $query->params('test', [':id' => 100])->getSql();
+        $sql   = $query->bindParamsFromArray(['test', ':id' => 100])->getSql();
         $this->assertEquals("select * from test where id = 100 and name = 'test'", $sql);
         */
     }
@@ -30,28 +30,28 @@ class QueryTest extends TestCase
     public function testGetSqlReturnsQuestionMarkReplacedWhenBound()
     {
         $query = new Query('select ?');
-        $sql   = $query->bindParams('hello')->getSql();
+        $sql   = $query->bindParamsFromArray(['hello'])->getSql();
         $this->assertEquals("select 'hello'", $sql);
     }
 
     public function testGetSqlReturnsQuestionMarkReplacedWhenBoundFromLastCall()
     {
         $query = new Query('select ?');
-        $sql   = $query->bindParams('foo')->bindParams('bar')->getSql();
+        $sql   = $query->bindParamsFromArray(['foo'])->bindParamsFromArray(['bar'])->getSql();
         $this->assertEquals("select 'bar'", $sql);
     }
 
     public function testGetSqlReturnsQuestionMarkReplacedWithNullValueWhenBound()
     {
         $query = new Query('select ?');
-        $sql   = $query->bindParams(null)->getSql();
+        $sql   = $query->bindParamsFromArray([null])->getSql();
         $this->assertEquals("select NULL", $sql);
     }
 
     public function testGetSqlReturnsQuestionMarkReplacedFromBoundWhenBound()
     {
         $query = new Query('select CONCAT(?, ?)');
-        $sql   = $query->bindParams('hello??', 'world??')->getSql();
+        $sql   = $query->bindParamsFromArray(['hello??', 'world??'])->getSql();
         $this->assertEquals("select CONCAT('hello??', 'world??')", $sql);
     }
 

--- a/tests/Io/QueryTest.php
+++ b/tests/Io/QueryTest.php
@@ -9,57 +9,42 @@ class QueryTest extends TestCase
 {
     public function testBindParams()
     {
-        $query = new Query('select * from test where id = ? and name = ?');
-        $sql   = $query->bindParamsFromArray([100, 'test'])->getSql();
-        $this->assertEquals("select * from test where id = 100 and name = 'test'", $sql);
+        $query = new Query('select * from test where id = ? and name = ?', [100, 'test']);
+        $this->assertEquals("select * from test where id = 100 and name = 'test'", $query->getSql());
 
-        $query = new Query('select * from test where id in (?,?) and name = ?');
-        $sql   = $query->bindParamsFromArray([1, 2, 'test'])->getSql();
-        $this->assertEquals("select * from test where id in (1,2) and name = 'test'", $sql);
+        $query = new Query('select * from test where id in (?,?) and name = ?', [1, 2, 'test']);
+        $this->assertEquals("select * from test where id in (1,2) and name = 'test'", $query->getSql());
         /*
-        $query = new Query('select * from test where id = :id and name = :name');
-        $sql   = $query->bindParamsFromArray([':id' => 100, ':name' => 'test'])->getSql();
-        $this->assertEquals("select * from test where id = 100 and name = 'test'", $sql);
+        $query = new Query('select * from test where id = :id and name = :name', [':id' => 100, ':name' => 'test']);
+        $this->assertEquals("select * from test where id = 100 and name = 'test'", $query->getSql());
 
-        $query = new Query('select * from test where id = :id and name = ?');
-        $sql   = $query->bindParamsFromArray(['test', ':id' => 100])->getSql();
-        $this->assertEquals("select * from test where id = 100 and name = 'test'", $sql);
+        $query = new Query('select * from test where id = :id and name = ?', ['test', ':id' => 100]);
+        $this->assertEquals("select * from test where id = 100 and name = 'test'", $query->getSql());
         */
     }
 
     public function testGetSqlReturnsQuestionMarkReplacedWhenBound()
     {
-        $query = new Query('select ?');
-        $sql   = $query->bindParamsFromArray(['hello'])->getSql();
-        $this->assertEquals("select 'hello'", $sql);
-    }
-
-    public function testGetSqlReturnsQuestionMarkReplacedWhenBoundFromLastCall()
-    {
-        $query = new Query('select ?');
-        $sql   = $query->bindParamsFromArray(['foo'])->bindParamsFromArray(['bar'])->getSql();
-        $this->assertEquals("select 'bar'", $sql);
+        $query = new Query('select ?', ['hello']);
+        $this->assertEquals("select 'hello'", $query->getSql());
     }
 
     public function testGetSqlReturnsQuestionMarkReplacedWithNullValueWhenBound()
     {
-        $query = new Query('select ?');
-        $sql   = $query->bindParamsFromArray([null])->getSql();
-        $this->assertEquals("select NULL", $sql);
+        $query = new Query('select ?', [null]);
+        $this->assertEquals("select NULL", $query->getSql());
     }
 
     public function testGetSqlReturnsQuestionMarkReplacedFromBoundWhenBound()
     {
-        $query = new Query('select CONCAT(?, ?)');
-        $sql   = $query->bindParamsFromArray(['hello??', 'world??'])->getSql();
-        $this->assertEquals("select CONCAT('hello??', 'world??')", $sql);
+        $query = new Query('select CONCAT(?, ?)', ['hello??', 'world??']);
+        $this->assertEquals("select CONCAT('hello??', 'world??')", $query->getSql());
     }
 
     public function testGetSqlReturnsQuestionMarksAsIsWhenNotBound()
     {
         $query = new Query('select "hello?"');
-        $sql   = $query->getSql();
-        $this->assertEquals("select \"hello?\"", $sql);
+        $this->assertEquals("select \"hello?\"", $query->getSql());
     }
 
     public function testEscapeChars()

--- a/tests/MysqlClientTest.php
+++ b/tests/MysqlClientTest.php
@@ -1921,6 +1921,40 @@ class MysqlClientTest extends BaseTestCase
         $ret->then($this->expectCallableNever(), $this->expectCallableOnce());
     }
 
+    public function testQueryThrowsForInvalidQueryParamsWithoutCreatingNewConnection()
+    {
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory->expects($this->never())->method('createConnection');
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $connection = new MysqlClient('', null, $loop);
+
+        $ref = new \ReflectionProperty($connection, 'factory');
+        $ref->setAccessible(true);
+        $ref->setValue($connection, $factory);
+
+        $this->setExpectedException('InvalidArgumentException', 'Query param must be of type string|int|float|bool|null, array given');
+        $connection->query('SELECT ?', [[]]);
+    }
+
+    public function testQueryThrowsForInvalidQueryParamsWhenConnectionIsAlreadyClosed()
+    {
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory->expects($this->never())->method('createConnection');
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $connection = new MysqlClient('', null, $loop);
+
+        $ref = new \ReflectionProperty($connection, 'factory');
+        $ref->setAccessible(true);
+        $ref->setValue($connection, $factory);
+
+        $connection->close();
+
+        $this->setExpectedException('InvalidArgumentException', 'Query param must be of type string|int|float|bool|null, array given');
+        $connection->query('SELECT ?', [[]]);
+    }
+
     public function testQueryStreamThrowsAfterConnectionIsClosed()
     {
         $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
@@ -1937,6 +1971,40 @@ class MysqlClientTest extends BaseTestCase
 
         $this->setExpectedException('React\Mysql\Exception');
         $connection->queryStream('SELECT 1');
+    }
+
+    public function testQueryStreamThrowsForInvalidQueryParamsWithoutCreatingNewConnection()
+    {
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory->expects($this->never())->method('createConnection');
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $connection = new MysqlClient('', null, $loop);
+
+        $ref = new \ReflectionProperty($connection, 'factory');
+        $ref->setAccessible(true);
+        $ref->setValue($connection, $factory);
+
+        $this->setExpectedException('InvalidArgumentException', 'Query param must be of type string|int|float|bool|null, stdClass given');
+        $connection->queryStream('SELECT ?', [new \stdClass()]);
+    }
+
+    public function testQueryStreamThrowsForInvalidQueryParamsWhenConnectionIsAlreadyClosed()
+    {
+        $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
+        $factory->expects($this->never())->method('createConnection');
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $connection = new MysqlClient('', null, $loop);
+
+        $ref = new \ReflectionProperty($connection, 'factory');
+        $ref->setAccessible(true);
+        $ref->setValue($connection, $factory);
+
+        $connection->close();
+
+        $this->setExpectedException('InvalidArgumentException', 'Query param must be of type string|int|float|bool|null, stdClass given');
+        $connection->queryStream('SELECT ?', [new \stdClass()]);
     }
 
     public function testPingReturnsRejectedPromiseAfterConnectionIsClosed()

--- a/tests/MysqlClientTest.php
+++ b/tests/MysqlClientTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\Mysql;
 
 use React\Mysql\Io\Connection;
+use React\Mysql\Io\Query;
 use React\Mysql\MysqlClient;
 use React\Mysql\MysqlResult;
 use React\Promise\Deferred;
@@ -191,7 +192,7 @@ class MysqlClientTest extends BaseTestCase
     public function testQueryWillCreateNewConnectionAndReturnPendingPromiseWhenConnectionResolvesAndQueryOnConnectionIsPending()
     {
         $connection = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
-        $connection->expects($this->once())->method('query')->with('SELECT 1')->willReturn(new Promise(function () { }));
+        $connection->expects($this->once())->method('query')->with(new Query('SELECT 1'))->willReturn(new Promise(function () { }));
 
         $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
@@ -212,7 +213,7 @@ class MysqlClientTest extends BaseTestCase
     {
         $result = new MysqlResult();
         $connection = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
-        $connection->expects($this->once())->method('query')->with('SELECT 1')->willReturn(\React\Promise\resolve($result));
+        $connection->expects($this->once())->method('query')->with(new Query('SELECT 1'))->willReturn(\React\Promise\resolve($result));
 
         $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
@@ -249,7 +250,7 @@ class MysqlClientTest extends BaseTestCase
     public function testQueryWillReturnRejectedPromiseWhenQueryOnConnectionRejectsAfterCreateConnectionResolves()
     {
         $connection = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
-        $connection->expects($this->once())->method('query')->with('SELECT 1')->willReturn(\React\Promise\reject(new \RuntimeException()));
+        $connection->expects($this->once())->method('query')->with(new Query('SELECT 1'))->willReturn(\React\Promise\reject(new \RuntimeException()));
 
         $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
@@ -289,7 +290,7 @@ class MysqlClientTest extends BaseTestCase
     public function testQueryTwiceWillCallQueryOnConnectionOnlyOnceWhenQueryIsStillPending()
     {
         $connection = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
-        $connection->expects($this->once())->method('query')->with('SELECT 1')->willReturn(new Promise(function () { }));
+        $connection->expects($this->once())->method('query')->with(new Query('SELECT 1'))->willReturn(new Promise(function () { }));
         $connection->expects($this->once())->method('isBusy')->willReturn(true);
 
         $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
@@ -313,8 +314,8 @@ class MysqlClientTest extends BaseTestCase
     {
         $connection = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $connection->expects($this->exactly(2))->method('query')->withConsecutive(
-            ['SELECT 1'],
-            ['SELECT 2']
+            [new Query('SELECT 1')],
+            [new Query('SELECT 2')]
         )->willReturnOnConsecutiveCalls(
             \React\Promise\resolve(new MysqlResult()),
             new Promise(function () { })
@@ -342,8 +343,8 @@ class MysqlClientTest extends BaseTestCase
     {
         $connection = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $connection->expects($this->exactly(2))->method('query')->withConsecutive(
-            ['SELECT 1'],
-            ['SELECT 2']
+            [new Query('SELECT 1')],
+            [new Query('SELECT 2')]
         )->willReturnOnConsecutiveCalls(
             \React\Promise\resolve(new MysqlResult()),
             new Promise(function () { })
@@ -373,7 +374,7 @@ class MysqlClientTest extends BaseTestCase
     public function testQueryTwiceWillCreateNewConnectionForSecondQueryWhenFirstConnectionIsClosedAfterFirstQueryIsResolved()
     {
         $connection = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->setMethods(['query', 'isBusy'])->getMock();
-        $connection->expects($this->once())->method('query')->with('SELECT 1')->willReturn(\React\Promise\resolve(new MysqlResult()));
+        $connection->expects($this->once())->method('query')->with(new Query('SELECT 1'))->willReturn(\React\Promise\resolve(new MysqlResult()));
         $connection->expects($this->never())->method('isBusy');
 
         $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
@@ -402,7 +403,7 @@ class MysqlClientTest extends BaseTestCase
     public function testQueryTwiceWillCloseFirstConnectionAndCreateNewConnectionForSecondQueryWhenFirstConnectionIsInClosingStateDueToIdleTimerAfterFirstQueryIsResolved()
     {
         $connection = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->setMethods(['query', 'isBusy', 'close'])->getMock();
-        $connection->expects($this->once())->method('query')->with('SELECT 1')->willReturn(\React\Promise\resolve(new MysqlResult()));
+        $connection->expects($this->once())->method('query')->with(new Query('SELECT 1'))->willReturn(\React\Promise\resolve(new MysqlResult()));
         $connection->expects($this->once())->method('close');
         $connection->expects($this->never())->method('isBusy');
 
@@ -511,8 +512,8 @@ class MysqlClientTest extends BaseTestCase
     {
         $connection = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $connection->expects($this->exactly(2))->method('query')->withConsecutive(
-            ['SELECT 1'],
-            ['SELECT 2']
+            [new Query('SELECT 1')],
+            [new Query('SELECT 2')]
         )->willReturnOnConsecutiveCalls(
             \React\Promise\reject(new \RuntimeException()),
             new Promise(function () { })
@@ -561,7 +562,7 @@ class MysqlClientTest extends BaseTestCase
     public function testQueryStreamWillCreateNewConnectionAndReturnReadableStreamWhenConnectionResolvesAndQueryStreamOnConnectionReturnsReadableStream()
     {
         $connection = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
-        $connection->expects($this->once())->method('queryStream')->with('SELECT 1')->willReturn(new ThroughStream());
+        $connection->expects($this->once())->method('queryStream')->with(new Query('SELECT 1'))->willReturn(new ThroughStream());
 
         $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($connection));
@@ -581,7 +582,7 @@ class MysqlClientTest extends BaseTestCase
     public function testQueryStreamTwiceWillCallQueryStreamOnConnectionOnlyOnceWhenQueryStreamIsStillReadable()
     {
         $connection = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
-        $connection->expects($this->once())->method('queryStream')->with('SELECT 1')->willReturn(new ThroughStream());
+        $connection->expects($this->once())->method('queryStream')->with(new Query('SELECT 1'))->willReturn(new ThroughStream());
         $connection->expects($this->once())->method('isBusy')->willReturn(true);
 
         $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
@@ -605,8 +606,8 @@ class MysqlClientTest extends BaseTestCase
     {
         $connection = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $connection->expects($this->exactly(2))->method('queryStream')->withConsecutive(
-            ['SELECT 1'],
-            ['SELECT 2']
+            [new Query('SELECT 1')],
+            [new Query('SELECT 2')]
         )->willReturnOnConsecutiveCalls(
             $base = new ThroughStream(),
             new ThroughStream()
@@ -636,8 +637,8 @@ class MysqlClientTest extends BaseTestCase
     {
         $connection = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $connection->expects($this->exactly(2))->method('queryStream')->withConsecutive(
-            ['SELECT 1'],
-            ['SELECT 2']
+            [new Query('SELECT 1')],
+            [new Query('SELECT 2')]
         )->willReturnOnConsecutiveCalls(
             $base = new ThroughStream(),
             new ThroughStream()
@@ -669,7 +670,7 @@ class MysqlClientTest extends BaseTestCase
     public function testQueryStreamTwiceWillWaitForFirstQueryStreamToEndBeforeStartingSecondQueryStreamWhenFirstQueryStreamIsExplicitlyClosed()
     {
         $connection = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
-        $connection->expects($this->once())->method('queryStream')->with('SELECT 1')->willReturn(new ThroughStream());
+        $connection->expects($this->once())->method('queryStream')->with(new Query('SELECT 1'))->willReturn(new ThroughStream());
         $connection->expects($this->once())->method('isBusy')->willReturn(true);
 
         $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
@@ -698,8 +699,8 @@ class MysqlClientTest extends BaseTestCase
     {
         $connection = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
         $connection->expects($this->exactly(2))->method('queryStream')->withConsecutive(
-            ['SELECT 1'],
-            ['SELECT 2']
+            [new Query('SELECT 1')],
+            [new Query('SELECT 2')]
         )->willReturnOnConsecutiveCalls(
             $base = new ThroughStream(),
             new ThroughStream()
@@ -730,7 +731,7 @@ class MysqlClientTest extends BaseTestCase
     public function testQueryStreamTwiceWillCreateNewConnectionForSecondQueryStreamWhenFirstConnectionIsClosedAfterFirstQueryStreamIsClosed()
     {
         $connection = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->setMethods(['queryStream', 'isBusy'])->getMock();
-        $connection->expects($this->once())->method('queryStream')->with('SELECT 1')->willReturn($base = new ThroughStream());
+        $connection->expects($this->once())->method('queryStream')->with(new Query('SELECT 1'))->willReturn($base = new ThroughStream());
         $connection->expects($this->never())->method('isBusy');
 
         $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
@@ -760,7 +761,7 @@ class MysqlClientTest extends BaseTestCase
     public function testQueryStreamTwiceWillCloseFirstConnectionAndCreateNewConnectionForSecondQueryStreamWhenFirstConnectionIsInClosingStateDueToIdleTimerAfterFirstQueryStreamIsClosed()
     {
         $connection = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->setMethods(['queryStream', 'isBusy', 'close'])->getMock();
-        $connection->expects($this->once())->method('queryStream')->with('SELECT 1')->willReturn($base = new ThroughStream());
+        $connection->expects($this->once())->method('queryStream')->with(new Query('SELECT 1'))->willReturn($base = new ThroughStream());
         $connection->expects($this->once())->method('close');
         $connection->expects($this->never())->method('isBusy');
 
@@ -1207,7 +1208,7 @@ class MysqlClientTest extends BaseTestCase
         $result = new MysqlResult();
 
         $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
-        $base->expects($this->once())->method('query')->with('SELECT 1')->willReturn(\React\Promise\resolve($result));
+        $base->expects($this->once())->method('query')->with(new Query('SELECT 1'))->willReturn(\React\Promise\resolve($result));
 
         $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
@@ -1230,7 +1231,7 @@ class MysqlClientTest extends BaseTestCase
         $deferred = new Deferred();
 
         $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
-        $base->expects($this->once())->method('query')->with('SELECT 1')->willReturn($deferred->promise());
+        $base->expects($this->once())->method('query')->with(new Query('SELECT 1'))->willReturn($deferred->promise());
         $base->expects($this->once())->method('ping')->willReturn(new Promise(function () { }));
 
         $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
@@ -1257,7 +1258,7 @@ class MysqlClientTest extends BaseTestCase
         $error = new \RuntimeException();
 
         $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
-        $base->expects($this->once())->method('query')->with('SELECT 1')->willReturn(\React\Promise\reject($error));
+        $base->expects($this->once())->method('query')->with(new Query('SELECT 1'))->willReturn(\React\Promise\reject($error));
 
         $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
@@ -1317,7 +1318,7 @@ class MysqlClientTest extends BaseTestCase
     {
         $stream = new ThroughStream();
         $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
-        $base->expects($this->once())->method('queryStream')->with('SELECT 1')->willReturn($stream);
+        $base->expects($this->once())->method('queryStream')->with(new Query('SELECT 1'))->willReturn($stream);
 
         $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));
@@ -1342,7 +1343,7 @@ class MysqlClientTest extends BaseTestCase
     {
         $stream = new ThroughStream();
         $base = $this->getMockBuilder('React\Mysql\Io\Connection')->disableOriginalConstructor()->getMock();
-        $base->expects($this->once())->method('queryStream')->with('SELECT 1')->willReturn($stream);
+        $base->expects($this->once())->method('queryStream')->with(new Query('SELECT 1'))->willReturn($stream);
 
         $factory = $this->getMockBuilder('React\Mysql\Io\Factory')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())->method('createConnection')->willReturn(\React\Promise\resolve($base));

--- a/tests/NoResultQueryTest.php
+++ b/tests/NoResultQueryTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\Mysql;
 
 use React\EventLoop\Loop;
+use React\Mysql\Io\Query;
 use React\Mysql\MysqlClient;
 use React\Mysql\MysqlResult;
 
@@ -16,8 +17,8 @@ class NoResultQueryTest extends BaseTestCase
         $connection = $this->createConnection(Loop::get());
 
         // re-create test "book" table
-        $connection->query('DROP TABLE IF EXISTS book');
-        $connection->query($this->getDataTable());
+        $connection->query(new Query('DROP TABLE IF EXISTS book'));
+        $connection->query(new Query($this->getDataTable()));
 
         $connection->quit();
         Loop::run();
@@ -27,7 +28,7 @@ class NoResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('update book set created=999 where id=999')->then(function (MysqlResult $command) {
+        $connection->query(new Query('update book set created=999 where id=999'))->then(function (MysqlResult $command) {
             $this->assertEquals(0, $command->affectedRows);
         });
 
@@ -39,7 +40,7 @@ class NoResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query("insert into book (`name`) values ('foo')")->then(function (MysqlResult $command) {
+        $connection->query(new Query("insert into book (`name`) values ('foo')"))->then(function (MysqlResult $command) {
             $this->assertEquals(1, $command->affectedRows);
             $this->assertEquals(1, $command->insertId);
         });
@@ -52,8 +53,8 @@ class NoResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query("insert into book (`name`) values ('foo')");
-        $connection->query('update book set created=999 where id=1')->then(function (MysqlResult $command) {
+        $connection->query(new Query("insert into book (`name`) values ('foo')"));
+        $connection->query(new Query('update book set created=999 where id=1'))->then(function (MysqlResult $command) {
             $this->assertEquals(1, $command->affectedRows);
         });
 
@@ -75,7 +76,7 @@ CREATE TABLE IF NOT EXISTS `book` (
     PRIMARY KEY (`id`)
 )';
 
-        $connection->query($sql)->then(function (MysqlResult $command) {
+        $connection->query(new Query($sql))->then(function (MysqlResult $command) {
             // 3 warnings on MySQL 8+, 1 warning on legacy MySQL 5
             $this->assertGreaterThanOrEqual(1, $command->warningCount);
         });

--- a/tests/ResultQueryTest.php
+++ b/tests/ResultQueryTest.php
@@ -4,6 +4,7 @@ namespace React\Tests\Mysql;
 
 use React\EventLoop\Loop;
 use React\Mysql\Io\Constants;
+use React\Mysql\Io\Query;
 use React\Mysql\MysqlClient;
 use React\Mysql\MysqlResult;
 
@@ -13,7 +14,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select \'foo\'')->then(function (MysqlResult $command) {
+        $connection->query(new Query('select \'foo\''))->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertSame('foo', reset($command->resultRows[0]));
@@ -51,7 +52,7 @@ class ResultQueryTest extends BaseTestCase
 
         $expected = $value;
 
-        $connection->query('select ?', [$value])->then(function (MysqlResult $command) use ($expected) {
+        $connection->query(new Query('select ?', [$value]))->then(function (MysqlResult $command) use ($expected) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertSame($expected, reset($command->resultRows[0]));
@@ -75,8 +76,8 @@ class ResultQueryTest extends BaseTestCase
 
         $expected = $value;
 
-        $connection->query('SET SQL_MODE="NO_BACKSLASH_ESCAPES"');
-        $connection->query('select ?', [$value])->then(function (MysqlResult $command) use ($expected) {
+        $connection->query(new Query('SET SQL_MODE="NO_BACKSLASH_ESCAPES"'));
+        $connection->query(new Query('select ?', [$value]))->then(function (MysqlResult $command) use ($expected) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertSame($expected, reset($command->resultRows[0]));
@@ -103,7 +104,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select ?', [$value])->then(function (MysqlResult $command) use ($expected) {
+        $connection->query(new Query('select ?', [$value]))->then(function (MysqlResult $command) use ($expected) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertSame($expected, reset($command->resultRows[0]));
@@ -117,7 +118,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select \'hello?\'')->then(function (MysqlResult $command) {
+        $connection->query(new Query('select \'hello?\''))->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertEquals('hello?', reset($command->resultRows[0]));
@@ -134,7 +135,7 @@ class ResultQueryTest extends BaseTestCase
         $length = 40000;
         $value = str_repeat('.', $length);
 
-        $connection->query('SELECT ?', [$value])->then(function (MysqlResult $command) use ($length) {
+        $connection->query(new Query('SELECT ?', [$value]))->then(function (MysqlResult $command) use ($length) {
             $this->assertCount(1, $command->resultFields);
             $this->assertEquals($length * 4, $command->resultFields[0]['length']);
             $this->assertSame(Constants::FIELD_TYPE_VAR_STRING, $command->resultFields[0]['type']);
@@ -148,7 +149,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select \'foo\' as ``')->then(function (MysqlResult $command) {
+        $connection->query(new Query('select \'foo\' as ``'))->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertSame('foo', reset($command->resultRows[0]));
@@ -166,7 +167,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select null')->then(function (MysqlResult $command) {
+        $connection->query(new Query('select null'))->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertNull(reset($command->resultRows[0]));
@@ -183,7 +184,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select "foo" UNION select "bar"')->then(function (MysqlResult $command) {
+        $connection->query(new Query('select "foo" UNION select "bar"'))->then(function (MysqlResult $command) {
             $this->assertCount(2, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -199,7 +200,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select "foo" UNION select null')->then(function (MysqlResult $command) {
+        $connection->query(new Query('select "foo" UNION select null'))->then(function (MysqlResult $command) {
             $this->assertCount(2, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -218,7 +219,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select 0 UNION select null')->then(function (MysqlResult $command) {
+        $connection->query(new Query('select 0 UNION select null'))->then(function (MysqlResult $command) {
             $this->assertCount(2, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -237,7 +238,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select "foo" UNION select 1')->then(function (MysqlResult $command) {
+        $connection->query(new Query('select "foo" UNION select 1'))->then(function (MysqlResult $command) {
             $this->assertCount(2, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -256,7 +257,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select "foo" UNION select ""')->then(function (MysqlResult $command) {
+        $connection->query(new Query('select "foo" UNION select ""'))->then(function (MysqlResult $command) {
             $this->assertCount(2, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -272,7 +273,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select "foo" LIMIT 0')->then(function (MysqlResult $command) {
+        $connection->query(new Query('select "foo" LIMIT 0'))->then(function (MysqlResult $command) {
             $this->assertCount(0, $command->resultRows);
 
             $this->assertCount(1, $command->resultFields);
@@ -287,7 +288,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select "foo","bar"')->then(function (MysqlResult $command) {
+        $connection->query(new Query('select "foo","bar"'))->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(2, $command->resultRows[0]);
 
@@ -303,7 +304,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select "foo",""')->then(function (MysqlResult $command) {
+        $connection->query(new Query('select "foo",""'))->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(2, $command->resultRows[0]);
 
@@ -319,7 +320,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select \'\' as `first`, \'\' as `second`')->then(function (MysqlResult $command) {
+        $connection->query(new Query('select \'\' as `first`, \'\' as `second`'))->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(2, $command->resultRows[0]);
             $this->assertSame(['', ''], array_values($command->resultRows[0]));
@@ -337,7 +338,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select "foo" as `col`,"bar" as `col`')->then(function (MysqlResult $command) {
+        $connection->query(new Query('select "foo" as `col`,"bar" as `col`'))->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
 
@@ -356,7 +357,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('SELECT @@character_set_client')->then(function (MysqlResult $command) {
+        $connection->query(new Query('SELECT @@character_set_client'))->then(function (MysqlResult $command) {
             $this->assertCount(1, $command->resultRows);
             $this->assertCount(1, $command->resultRows[0]);
             $this->assertSame('utf8mb4', reset($command->resultRows[0]));
@@ -386,12 +387,12 @@ class ResultQueryTest extends BaseTestCase
         $connection = $this->createConnection(Loop::get());
 
         // re-create test "book" table
-        $connection->query('DROP TABLE IF EXISTS book');
-        $connection->query($this->getDataTable());
-        $connection->query("insert into book (`name`) values ('foo')");
-        $connection->query("insert into book (`name`) values ('bar')");
+        $connection->query(new Query('DROP TABLE IF EXISTS book'));
+        $connection->query(new Query($this->getDataTable()));
+        $connection->query(new Query("insert into book (`name`) values ('foo')"));
+        $connection->query(new Query("insert into book (`name`) values ('bar')"));
 
-        $connection->query('select * from book')->then(function (MysqlResult $command) {
+        $connection->query(new Query('select * from book'))->then(function (MysqlResult $command) {
             $this->assertCount(2, $command->resultRows);
         });
 
@@ -422,7 +423,7 @@ class ResultQueryTest extends BaseTestCase
         $options = $this->getConnectionOptions();
         $db = $options['dbname'];
 
-        $connection->query('select * from invalid_table')->then(
+        $connection->query(new Query('select * from invalid_table'))->then(
             $this->expectCallableNever(),
             function (\Exception $error) use ($db) {
                 $this->assertEquals("Table '$db.invalid_table' doesn't exist", $error->getMessage());
@@ -437,7 +438,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $connection->query('select 1;select 2;')->then(
+        $connection->query(new Query('select 1;select 2;'))->then(
             $this->expectCallableNever(),
             function (\Exception $error) {
                 if (method_exists($this, 'assertStringContainsString')) {
@@ -459,7 +460,7 @@ class ResultQueryTest extends BaseTestCase
         $connection = $this->createConnection(Loop::get());
 
         Loop::addTimer(0.1, function () use ($connection) {
-            $connection->query('select 1+1')->then(function (MysqlResult $command) {
+            $connection->query(new Query('select 1+1'))->then(function (MysqlResult $command) {
                 $this->assertEquals([['1+1' => 2]], $command->resultRows);
             });
             $connection->quit();
@@ -480,7 +481,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $stream = $connection->queryStream('SELECT 1');
+        $stream = $connection->queryStream(new Query('SELECT 1'));
         $stream->on('data', $this->expectCallableOnceWith(['1' => '1']));
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('close', $this->expectCallableOnce());
@@ -493,7 +494,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $stream = $connection->queryStream('SELECT ? as value', ['test']);
+        $stream = $connection->queryStream(new Query('SELECT ? as value', ['test']));
         $stream->on('data', $this->expectCallableOnceWith(['value' => 'test']));
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('close', $this->expectCallableOnce());
@@ -506,7 +507,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $stream = $connection->queryStream('SELECT 1 LIMIT 0');
+        $stream = $connection->queryStream(new Query('SELECT 1 LIMIT 0'));
         $stream->on('data', $this->expectCallableNever());
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('close', $this->expectCallableOnce());
@@ -519,7 +520,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $stream = $connection->queryStream('SELECT');
+        $stream = $connection->queryStream(new Query('SELECT'));
         $stream->on('data', $this->expectCallableNever());
         $stream->on('end', $this->expectCallableNever());
         $stream->on('error', $this->expectCallableOnce());
@@ -533,7 +534,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $stream = $connection->queryStream('DROP TABLE IF exists helloworldtest1');
+        $stream = $connection->queryStream(new Query('DROP TABLE IF exists helloworldtest1'));
         $stream->on('data', $this->expectCallableNever());
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('close', $this->expectCallableOnce());
@@ -546,7 +547,7 @@ class ResultQueryTest extends BaseTestCase
     {
         $connection = $this->createConnection(Loop::get());
 
-        $stream = $connection->queryStream('SELECT 1');
+        $stream = $connection->queryStream(new Query('SELECT 1'));
         $stream->on('data', $this->expectCallableNever());
         $stream->on('end', $this->expectCallableNever());
         $stream->on('close', $this->expectCallableOnce());


### PR DESCRIPTION
This changeset ensures we properly validate any query parameters and reject unsupported non-scalars such as objects/arrays/resources. This should be in line with the existing design and should not affect any existing code using scalar or `null` values.

```php
// old (still supported)
$mysql->query('SELECT * FROM user WHERE name = ? and age > ?', ['Alice', 42]);

// now throws an InvalidArgumentException for invalid params
$mysql->query('SELECT ?', [new stdClass()]);
```

Most notably, this fixes an old bug that would invalidate the entire connection object if an unexpected value is passed as discussed in #167. With these changes applied, it will now properly reject any invalid values, leaving the connection in a valid state for any following queries. The affected code comes with updated tests that have 100% code coverage.

Additionally, it adds some stricter types to the public API that makes it easier to detect this problem for any static analysis tools such as PHPStan or your favorite IDE.

On top of this, this is done in preparation for named query params as discussed in #41. Among others, this will change the `list` type to an `array` type again. I'll file a follow-up PR once this one is in.

If you want to support this project, please consider [sponsoring @reactphp](https://github.com/sponsors/reactphp) – sponsorships really do make a difference ❤️

Builds on top of #210, #186, #40, https://github.com/clue/reactphp-redis/pull/171, and others
Resolves / closes #167
Refs #41