### PR TITLE
Update failing tests with invalid URIs

### DIFF
--- a/tests/MysqlClientTest.php
+++ b/tests/MysqlClientTest.php
@@ -1994,7 +1994,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->never())->method('createConnection');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -2010,7 +2010,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->never())->method('createConnection');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -2046,7 +2046,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->never())->method('createConnection');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);
@@ -2062,7 +2062,7 @@ class MysqlClientTest extends BaseTestCase
         $factory->expects($this->never())->method('createConnection');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $connection = new MysqlClient('', null, $loop);
+        $connection = new MysqlClient('localhost', null, $loop);
 
         $ref = new \ReflectionProperty($connection, 'factory');
         $ref->setAccessible(true);


### PR DESCRIPTION
This simple changeset fixes a few failing tests introduced earlier today due to an unfortunate merge sequence between #210 and #211. This error did not show in isolation earlier as both features branched off at the same commit, duh.

Builds on top of #211 and #210